### PR TITLE
Fixed issue with Table Header sticky CSS

### DIFF
--- a/src/lib/molecules/tables/inifinite-scroll-table.js
+++ b/src/lib/molecules/tables/inifinite-scroll-table.js
@@ -57,7 +57,7 @@ class InfiniteScrollTable extends React.Component {
             <Table.Row textAlign="center">
               {map(headerCells, (element, index) =>
                 <Table.HeaderCell key={index}>
-                  <Sticky context={contextRef}>
+                  <Sticky className="genomix sticky th" context={contextRef}>
                     <div className="genomix infinite th">
                       {element}
                     </div>

--- a/src/stylesheets/partials/tables.scss
+++ b/src/stylesheets/partials/tables.scss
@@ -2,6 +2,10 @@
   padding: 0;
 }
 
+.genomix.sticky.th > * {
+  z-index: 99;
+}
+
 .genomix.infinite.th {
   background: genomix-color('th-background');
   padding-top: 15px;


### PR DESCRIPTION
Dear Maintainers,

Please accept this PR that addresses the following issues:
+ *When Table Header was stuck, some elements would be overlayed on top (image attached)*

<img width="1440" alt="screen shot 2017-12-12 at 11 19 14 am" src="https://user-images.githubusercontent.com/18250655/33897020-56cd5978-df32-11e7-849f-2527ba56be53.png">
