### PR TITLE
Added customized columns for react-virtualized Table

### DIFF
--- a/src/demo/App.js
+++ b/src/demo/App.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import { Grid } from 'semantic-ui-react'
 
 // Demo Components
 import Example from './components/Example'
@@ -8,6 +7,7 @@ import Buttons from './components/Buttons'
 import Icons from './components/Icons'
 import Forms from './components/Forms'
 import BigDataTableExample from './components/BigDataTableExample'
+import ExampleTableCells from './components/TableCellExamples'
 
 
 const App = () => (
@@ -17,12 +17,8 @@ const App = () => (
     <Buttons />
     <Icons />
     <Forms />
-    <Grid>
-      <Grid.Column width={8}>
-        <BigDataTableExample />
-      </Grid.Column>
-    </Grid>
-
+    <ExampleTableCells />
+    <BigDataTableExample />
   </div>
 )
 

--- a/src/demo/components/BigDataTableExample.js
+++ b/src/demo/components/BigDataTableExample.js
@@ -1,31 +1,34 @@
 import React from 'react'
 import { Column } from 'react-virtualized'
+import { Grid } from 'semantic-ui-react'
 
 import { BigDataTable } from 'LibIndex'
 
 
 const list = Array.from(new Array(30), (x,i) => ({
-  name: 'Brian Vaughn',
-  description: 'Software engineer'
+  base: 'Base',
+  checkbox: true,
+  dropdown: 1,
+  link: 'http://www.google.com',
+  text: 'Text',
 }))
 
 
 const ExampleInfiniteTable = () => (
-  <BigDataTable
-    data={list}
-    height={400}
-  >
-    <Column
-      label="Name"
-      dataKey="name"
-      width={100}
-    />
-    <Column
-      label="Description"
-      dataKey="description"
-      width={150}
-    />
-  </BigDataTable>
+  <Grid>
+    <Grid.Column width={12}>
+      <BigDataTable
+        data={list}
+        height={400}
+      >
+        <Column
+          label="Base Column"
+          dataKey="base"
+          width={150}
+        />
+      </BigDataTable>
+    </Grid.Column>
+  </Grid>
 )
 
 export default ExampleInfiniteTable

--- a/src/demo/components/TableCellExamples.js
+++ b/src/demo/components/TableCellExamples.js
@@ -1,0 +1,76 @@
+import React from 'react'
+import { Table } from 'semantic-ui-react'
+
+import { CheckboxCell, DropdownCell, TextCell, LinkCell } from 'LibIndex'
+
+
+class ExampleTableCells extends React.Component {
+  constructor(props) {
+    super(props)
+
+    this.state = {
+      value: ''
+    }
+  }
+
+  onChange = (index) => {
+    alert(index)
+  }
+
+  onChange2 = (data) => {
+    alert(JSON.stringify(data))
+  }
+
+  render() {
+    const { value } = this.state
+
+    return (
+      <Table>
+
+        <Table.Header>
+          <Table.Row>
+            <Table.HeaderCell>
+              Checkbox
+            </Table.HeaderCell>
+            <Table.HeaderCell>
+              Dropdown
+            </Table.HeaderCell>
+            <Table.HeaderCell>
+              Text
+            </Table.HeaderCell>
+            <Table.HeaderCell>
+              Link
+            </Table.HeaderCell>
+          </Table.Row>
+        </Table.Header>
+
+        <Table.Body>
+          <Table.Row>
+            <CheckboxCell
+              as="td"
+              rowIndex={1}
+              onChange={this.onChange}
+            />
+            <DropdownCell
+              as="td"
+              name="test"
+              value={value}
+              rowIndex={1}
+              onChange={this.onChange2}
+              options={[
+                { key: 'key1', value: 1, text: '1', content: <h1>Hi Mike</h1>},
+                { key: 'key2', value: 2, text: '2'}
+              ]}
+            />
+            <TextCell as="td" content="text" />
+            <LinkCell as="td" path="http://www.google.com" content="google" />
+          </Table.Row>
+        </Table.Body>
+
+      </Table>
+    )
+  }
+}
+
+
+export default ExampleTableCells

--- a/src/lib/atoms/table-cells/checkbox-cell.js
+++ b/src/lib/atoms/table-cells/checkbox-cell.js
@@ -1,0 +1,34 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Table, Checkbox } from 'semantic-ui-react'
+
+
+class CheckboxCell extends React.PureComponent {
+  onChange = (e) => {
+    const { onChange, rowIndex } = this.props
+    onChange(rowIndex)
+  }
+
+  render() {
+    const { as, onChange, rowIndex, ...rest } = this.props
+
+    if (as === 'td') {
+      return <Table.Cell {...rest}><Checkbox onChange={this.onChange} /></Table.Cell>
+    } else {
+      return <div><Checkbox onChange={this.onChange} /></div>
+    }
+  }
+}
+
+
+CheckboxCell.propTypes = {
+  as: PropTypes.oneOf(['td', 'div']),
+  onChange: PropTypes.func.isRequired,
+  rowIndex: PropTypes.number.isRequired,
+}
+
+CheckboxCell.defaultProps = {
+  as: 'div'
+}
+
+export default CheckboxCell

--- a/src/lib/atoms/table-cells/checkbox-cell.test.js
+++ b/src/lib/atoms/table-cells/checkbox-cell.test.js
@@ -1,0 +1,32 @@
+import React from 'react'
+import ReactDOM from 'react-dom'
+import { shallow } from 'enzyme'
+
+import CheckboxCell from './checkbox-cell'
+
+
+describe('Test CheckboxCell', () => {
+  it('CheckboxCell renders without crashing', () => {
+    const div = document.createElement('div')
+    ReactDOM.render(<CheckboxCell rowIndex={1} onChange={jest.fn()} />, div)
+  })
+
+  it('CheckboxCell initial props are set correctly', () => {
+    const wrapper = shallow(<CheckboxCell rowIndex={1} onChange={jest.fn()} />)
+    expect(wrapper.instance().props.rowIndex).toEqual(1)
+    expect(wrapper.instance().props.as).toEqual('div')
+  })
+
+  it('CheckboxCell initial props are set correctly as td', () => {
+    const wrapper = shallow(<CheckboxCell as="td" rowIndex={1} onChange={jest.fn()} />)
+    expect(wrapper.instance().props.rowIndex).toEqual(1)
+    expect(wrapper.instance().props.as).toEqual('td')
+  })
+
+  it('CheckboxCell onChange is called correctly', () => {
+    const onChange = jest.fn()
+    const wrapper = shallow(<CheckboxCell rowIndex={1} onChange={onChange} />)
+    wrapper.find('Checkbox').simulate('change')
+    expect(onChange).toHaveBeenCalledWith(1)
+  })
+})

--- a/src/lib/atoms/table-cells/dropdown-cell.js
+++ b/src/lib/atoms/table-cells/dropdown-cell.js
@@ -1,0 +1,93 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Table, Dropdown } from 'semantic-ui-react'
+
+
+class DropdownCell extends React.Component {
+  constructor(props) {
+    super(props)
+
+    this.state = {
+      value: ''
+    }
+  }
+
+  onChange = (e, { name, value }) => {
+    const { onChange, rowIndex } = this.props
+    onChange({ column: name, row: rowIndex, value: value })
+    this.setState({ value })
+  }
+
+  render() {
+    const { as, name, rowIndex, onChange, options, dropDownProps, ...rest } = this.props
+    const { value } = this.state
+
+    if (as === 'td') {
+      return (
+        <Table.Cell {...rest}>
+          <Dropdown
+            name={name}
+            value={value}
+            onChange={this.onChange}
+            options={options}
+            {...dropDownProps}
+          />
+        </Table.Cell>
+      )
+    } else {
+      return (
+        <div>
+          <Dropdown
+            name={name}
+            value={value}
+            onChange={this.onChange}
+            options={options}
+            {...dropDownProps}
+          />
+        </div>
+      )
+    }
+  }
+}
+
+
+DropdownCell.propTypes = {
+  as: PropTypes.oneOf(['td', 'div']),
+  name: PropTypes.string.isRequired,
+  rowIndex: PropTypes.number.isRequired,
+  onChange: PropTypes.func.isRequired,
+  dropDownProps: PropTypes.object,
+  options: PropTypes.arrayOf(
+    PropTypes.shape({
+      key: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.number,
+      ]).isRequired,
+      value: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.number,
+      ]).isRequired,
+      text: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.number,
+      ]).isRequired,
+      content: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.number,
+        PropTypes.element,
+      ]),
+    })
+  ).isRequired,
+}
+
+DropdownCell.defaultProps = {
+  as: 'div',
+  dropDownProps: {
+    fluid: false,
+    multiple: false,
+    selection: true,
+    search: true,
+  },
+}
+
+export default DropdownCell

--- a/src/lib/atoms/table-cells/dropdown-cell.test.js
+++ b/src/lib/atoms/table-cells/dropdown-cell.test.js
@@ -1,0 +1,75 @@
+import React from 'react'
+import ReactDOM from 'react-dom'
+import { shallow } from 'enzyme'
+
+import DropdownCell from './dropdown-cell'
+
+
+describe('Test DropdownCell', () => {
+  it('DropdownCell renders without crashing', () => {
+    const div = document.createElement('div')
+    const table = (
+      <DropdownCell
+        name="test"
+        rowIndex={1}
+        onChange={jest.fn()}
+        options={[{ key: 'key2', value: 2, text: '2'}]}
+      />
+    )
+    ReactDOM.render(table, div)
+  })
+
+  it('DropdownCell initial props are set correctly', () => {
+    const component = (
+      <DropdownCell
+        name="test"
+        rowIndex={1}
+        onChange={jest.fn()}
+        options={[{ key: 'key2', value: 2, text: '2'}]}
+      />
+    )
+    const wrapper = shallow(component)
+    expect(wrapper.instance().props.name).toEqual('test')
+    expect(wrapper.instance().props.rowIndex).toEqual(1)
+    expect(wrapper.instance().props.dropDownProps)
+      .toEqual({ fluid: false, multiple: false, selection: true, search: true })
+    expect(wrapper.instance().props.options)
+      .toEqual([{ key: 'key2', value: 2, text: '2'}])
+  })
+
+  it('DropdownCell initial props are set correctly as td', () => {
+    const component = (
+      <DropdownCell
+        as="td"
+        name="test"
+        rowIndex={1}
+        onChange={jest.fn()}
+        options={[{ key: 'key2', value: 2, text: '2'}]}
+      />
+    )
+    const wrapper = shallow(component)
+    expect(wrapper.instance().props.as).toEqual('td')
+    expect(wrapper.instance().props.name).toEqual('test')
+    expect(wrapper.instance().props.rowIndex).toEqual(1)
+    expect(wrapper.instance().props.dropDownProps)
+      .toEqual({ fluid: false, multiple: false, selection: true, search: true })
+    expect(wrapper.instance().props.options)
+      .toEqual([{ key: 'key2', value: 2, text: '2'}])
+  })
+
+  it('DropdownCell onChange is called correctly', () => {
+    const onChange = jest.fn()
+    const event = { target: { name: "test", value: 2 }}
+    const component = (
+      <DropdownCell
+        name="test"
+        rowIndex={1}
+        onChange={onChange}
+        options={[{ key: 'key2', value: 2, text: '2'}]}
+      />
+    )
+    const wrapper = shallow(component)
+    wrapper.find('Dropdown').simulate('change', event, { name: "test", value: 2 })
+    expect(onChange).toHaveBeenCalledWith({"column": "test", "row": 1, "value": 2})
+  })
+})

--- a/src/lib/atoms/table-cells/link-cell.js
+++ b/src/lib/atoms/table-cells/link-cell.js
@@ -1,0 +1,67 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Table } from 'semantic-ui-react'
+
+import { ExternalIcon, InfoIcon } from 'LibIndex'
+
+
+class LinkCell extends React.PureComponent {
+  render() {
+    const { as, content, linkAs, path, rowIndex, ...rest } = this.props
+
+    let link = (
+      <a
+        target="_blank"
+        rel="noopener noreferrer"
+        href={path}
+      >
+        {content} <ExternalIcon />
+      </a>
+    )
+
+    if (linkAs !== 'a') {
+      link = (
+        <linkAs to={path}>
+          {content} <InfoIcon />
+        </linkAs>
+      )
+    }
+
+    if (as === 'td') {
+      return (
+        <Table.Cell {...rest}>
+          {link}
+        </Table.Cell>
+      )
+    } else {
+      return (
+        <div>
+          {link}
+        </div>
+      )
+    }
+  }
+}
+
+
+LinkCell.propTypes = {
+  as: PropTypes.oneOf(['td', 'div']),
+  linkAs: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.func,
+  ]),
+  path: PropTypes.string.isRequired,
+  content: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number,
+    PropTypes.element,
+  ]).isRequired,
+  rowIndex: PropTypes.number,
+}
+
+LinkCell.defaultProps = {
+  as: 'div',
+  linkAs: 'a',
+}
+
+export default LinkCell

--- a/src/lib/atoms/table-cells/link-cell.test.js
+++ b/src/lib/atoms/table-cells/link-cell.test.js
@@ -1,0 +1,81 @@
+import React from 'react'
+import ReactDOM from 'react-dom'
+import { shallow } from 'enzyme'
+
+import LinkCell from './link-cell'
+
+
+describe('Test LinkCell', () => {
+  it('LinkCell renders without crashing', () => {
+    const div = document.createElement('div')
+    const component = (
+      <LinkCell
+        path="http://www.google.com"
+        content="hi"
+        rowIndex={1}
+      />
+    )
+    ReactDOM.render(component, div)
+  })
+
+  it('TextCell initial props are set correctly', () => {
+    const component = (
+      <LinkCell
+        path="http://www.google.com"
+        content="hi"
+        rowIndex={1}
+      />
+    )
+    const wrapper = shallow(component)
+    expect(wrapper.instance().props.as).toEqual('div')
+    expect(wrapper.instance().props.path).toEqual('http://www.google.com')
+    expect(wrapper.instance().props.content).toEqual('hi')
+    expect(wrapper.instance().props.rowIndex).toEqual(1)
+  })
+
+  it('LinkCell initial props are set correctly as td', () => {
+    const component = (
+      <LinkCell
+        as="td"
+        path="http://www.google.com"
+        content="hi"
+        rowIndex={1}
+      />
+    )
+    const wrapper = shallow(component)
+    expect(wrapper.instance().props.as).toEqual('td')
+    expect(wrapper.instance().props.path).toEqual('http://www.google.com')
+    expect(wrapper.instance().props.content).toEqual('hi')
+    expect(wrapper.instance().props.rowIndex).toEqual(1)
+  })
+
+  it('LinkCell link url is set correctly', () => {
+    const component = (
+      <LinkCell
+        path="app/1"
+        content="hi"
+        rowIndex={1}
+      />
+    )
+    const wrapper = shallow(component)
+    expect(wrapper.find('a').prop('href')).toEqual('app/1')
+    expect(wrapper.find('a').prop('target')).toEqual('_blank')
+    expect(wrapper.find('a').prop('rel')).toEqual('noopener noreferrer')
+  })
+
+  it('LinkCell link can use React-Router', () => {
+    const Link = ({ ...props }) => <p>{props.to}</p>
+
+    const component = (
+      <LinkCell
+        linkAs={Link}
+        path="app/1"
+        content="hi"
+        rowIndex={1}
+      />
+    )
+    const wrapper = shallow(component)
+    expect(wrapper.instance().props.linkAs).toEqual(Link)
+    expect(wrapper.find('linkAs').prop('to')).toEqual('app/1')
+  })
+})

--- a/src/lib/atoms/table-cells/text-cell.js
+++ b/src/lib/atoms/table-cells/text-cell.js
@@ -1,0 +1,33 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Table } from 'semantic-ui-react'
+
+
+class TextCell extends React.PureComponent {
+  render() {
+    const { as, content, rowIndex, ...rest } = this.props
+
+    if (as === 'td') {
+      return <Table.Cell {...rest}>{content}</Table.Cell>
+    } else {
+      return <div>{content}</div>
+    }
+  }
+}
+
+
+TextCell.propTypes = {
+  as: PropTypes.oneOf(['td', 'div']),
+  content: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number,
+    PropTypes.element,
+  ]).isRequired,
+  rowIndex: PropTypes.number,
+}
+
+TextCell.defaultProps = {
+  as: 'div'
+}
+
+export default TextCell

--- a/src/lib/atoms/table-cells/text-cell.test.js
+++ b/src/lib/atoms/table-cells/text-cell.test.js
@@ -1,0 +1,27 @@
+import React from 'react'
+import ReactDOM from 'react-dom'
+import { shallow } from 'enzyme'
+
+import TextCell from './text-cell'
+
+
+describe('Test TextCell', () => {
+  it('TextCell renders without crashing', () => {
+    const div = document.createElement('div')
+    ReactDOM.render(<TextCell rowIndex={1} content="hi" />, div)
+  })
+
+  it('TextCell initial props are set correctly', () => {
+    const wrapper = shallow(<TextCell rowIndex={1} content="hi" />)
+    expect(wrapper.instance().props.rowIndex).toEqual(1)
+    expect(wrapper.instance().props.as).toEqual('div')
+    expect(wrapper.instance().props.content).toEqual('hi')
+  })
+
+  it('TextCell initial props are set correctly as td', () => {
+    const wrapper = shallow(<TextCell as="td" rowIndex={1} content="hi" />)
+    expect(wrapper.instance().props.rowIndex).toEqual(1)
+    expect(wrapper.instance().props.as).toEqual('td')
+    expect(wrapper.instance().props.content).toEqual('hi')
+  })
+})

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -5,6 +5,7 @@ import 'react-virtualized/styles.css'
 
 
 // Atoms
+// Buttons
 import Button from 'LibSrc/atoms/buttons/Button'
 import ExportButton from 'LibSrc/atoms/buttons/ExportButton'
 import {
@@ -17,6 +18,7 @@ import {
   UploadButton,
 } from 'LibSrc/atoms/buttons/GenomiXButtons'
 
+// Icons
 import Icon from 'LibSrc/atoms/icons/Icon'
 import {
   AcceptIcon,
@@ -35,10 +37,28 @@ import {
   WarningIcon,
 } from 'LibSrc/atoms/icons/GenomiXIcons'
 
+// Table Cells
+import CheckboxCell from 'LibSrc/atoms/table-cells/checkbox-cell'
+import DropdownCell from 'LibSrc/atoms/table-cells/dropdown-cell'
+import LinkCell from 'LibSrc/atoms/table-cells/link-cell'
+import TextCell from 'LibSrc/atoms/table-cells/text-cell'
+
 
 // Molecules
+// Forms
 import SaveForm from 'LibSrc/molecules/forms/save-form'
+
+// Modals
 import SaveFormModal from 'LibSrc/molecules/modals/save-form-modal'
+
+// Table Columns
+import CheckboxColumn from 'LibSrc/molecules/table-columns/checkbox-column'
+import DropdownColumn from 'LibSrc/molecules/table-columns/dropdown-column'
+import LinkColumn from 'LibSrc/molecules/table-columns/link-column'
+import TextColumn from 'LibSrc/molecules/table-columns/text-column'
+
+
+// Tables
 import BigDataTable from 'LibSrc/molecules/tables/big-data-table'
 
 
@@ -74,10 +94,26 @@ export {
   WarningIcon,
 }
 
+// Export Table Cells
+export {
+  CheckboxCell,
+  DropdownCell,
+  LinkCell,
+  TextCell,
+}
+
 // Export Forms
 export {
   SaveForm,
   SaveFormModal,
+}
+
+// Export Table Columns
+export {
+  CheckboxColumn,
+  DropdownColumn,
+  LinkColumn,
+  TextColumn,
 }
 
 // Export Tables

--- a/src/lib/molecules/table-columns/checkbox-column.js
+++ b/src/lib/molecules/table-columns/checkbox-column.js
@@ -1,0 +1,71 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Column } from 'react-virtualized'
+import { get } from 'lodash'
+
+import { CheckboxCell } from 'LibIndex'
+
+
+// See: https://github.com/bvaughn/react-virtualized/pull/748
+// Note: Facebook argues against inheritance https://reactjs.org/docs/composition-vs-inheritance.html
+// But Table won't accept anything other than type of Column
+// Submitted an issue shown here: https://github.com/bvaughn/react-virtualized/issues/898
+
+
+class CheckboxColumn extends Column {
+  static propTypes = {
+    ...Column.propTypes,
+    onChange: PropTypes.func.isRequired,
+  }
+
+  static defaultProps = {
+    ...Column.defaultProps,
+  }
+
+  cellDataGetter = (props) => {
+    // See: https://github.com/bvaughn/react-virtualized/blob/master/docs/Column.md#celldatagetter
+    // props: { columnData, dataKey, rowData }
+    const { rowData, dataKey } = props
+    return get(rowData, dataKey, 'N/A')
+  }
+
+  cellRenderer = (props) => {
+    // See: https://github.com/bvaughn/react-virtualized/blob/master/docs/Column.md#cellrenderer
+    // props: { cellData, columnData, columnIndex, dataKey, isScrolling, rowData, rowIndex }
+    const { cellData, rowIndex } = props
+    const { onChange } = this.props
+
+    return (
+      <CheckboxCell
+        onChange={onChange}
+        content={cellData}
+        rowIndex={rowIndex}
+      />
+    )
+  }
+
+  headerRenderer = (props) => {
+    // See: https://github.com/bvaughn/react-virtualized/blob/master/docs/Column.md#headerrenderer
+    // props: { columnData, dataKey, disableSort, label, sortBy, sortDirection, }
+    const { label } = props
+    return <p>{label}</p>
+  }
+
+  render() {
+    const { label, dataKey, width } = this.props
+
+    return (
+      <Column
+        label={label}
+        dataKey={dataKey}
+        width={width}
+        cellDataGetter={this.cellDataGetter}
+        cellRenderer={this.cellRenderer}
+        headerRenderer={this.headerRenderer}
+      />
+    )
+  }
+}
+
+
+export default CheckboxColumn

--- a/src/lib/molecules/table-columns/checkbox-column.test.js
+++ b/src/lib/molecules/table-columns/checkbox-column.test.js
@@ -1,0 +1,56 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+
+import { CheckboxCell } from 'LibIndex'
+import CheckboxColumn from './checkbox-column'
+
+
+describe('Test CheckboxColumn', () => {
+  it('cellDataGetter returns expected content', () => {
+    const rowData = { name: 'mike', 'value': '1' }
+    const dataKey = 'name'
+    const element = (
+      <CheckboxColumn
+        label="test"
+        dataKey={dataKey}
+        width={100}
+        onChange={jest.fn()}
+      />
+    )
+    const wrapper = shallow(element)
+    expect(wrapper.find('Column').props().cellDataGetter({ rowData, dataKey }))
+      .toEqual('mike')
+  })
+
+  it('cellRenderer returns expected content', () => {
+    const cellData = 'mike'
+    const rowIndex = 1
+    const onChange = jest.fn()
+    const element = (
+      <CheckboxColumn
+        label="test"
+        dataKey="test"
+        width={100}
+        onChange={onChange}
+      />
+    )
+    const wrapper = shallow(element)
+    expect(wrapper.find('Column').props().cellRenderer({ cellData, rowIndex }))
+      .toEqual(<CheckboxCell as="div" onChange={onChange} content="mike" rowIndex={1} />)
+  })
+
+  it('headerRenderer returns expected content', () => {
+    const label = 'Mike Column'
+    const element = (
+      <CheckboxColumn
+        label={label}
+        dataKey="test"
+        width={100}
+        onChange={jest.fn()}
+      />
+    )
+    const wrapper = shallow(element)
+    expect(wrapper.find('Column').props().headerRenderer({label }))
+      .toEqual(<p>Mike Column</p>)
+  })
+})

--- a/src/lib/molecules/table-columns/dropdown-column.js
+++ b/src/lib/molecules/table-columns/dropdown-column.js
@@ -1,0 +1,102 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Column } from 'react-virtualized'
+import { get } from 'lodash'
+
+import { DropdownCell } from 'LibIndex'
+
+
+// See: https://github.com/bvaughn/react-virtualized/pull/748
+// Note: Facebook argues against inheritance https://reactjs.org/docs/composition-vs-inheritance.html
+// But Table won't accept anything other than type of Column
+// Submitted an issue shown here: https://github.com/bvaughn/react-virtualized/issues/898
+
+
+class DropdownColumn extends Column {
+  static propTypes = {
+    ...Column.propTypes,
+    onChange: PropTypes.func.isRequired,
+    dropDownProps: PropTypes.object,
+    options: PropTypes.arrayOf(
+      PropTypes.shape({
+        key: PropTypes.oneOfType([
+          PropTypes.string,
+          PropTypes.number,
+        ]).isRequired,
+        value: PropTypes.oneOfType([
+          PropTypes.string,
+          PropTypes.number,
+        ]).isRequired,
+        text: PropTypes.oneOfType([
+          PropTypes.string,
+          PropTypes.number,
+        ]).isRequired,
+        content: PropTypes.oneOfType([
+          PropTypes.string,
+          PropTypes.number,
+          PropTypes.element,
+        ]),
+      })
+    ).isRequired,
+  }
+
+  static defaultProps = {
+    ...Column.defaultProps,
+    dropDownProps: {
+      fluid: false,
+      multiple: false,
+      selection: true,
+      search: true,
+    },
+  }
+
+  cellDataGetter = (props) => {
+    // See: https://github.com/bvaughn/react-virtualized/blob/master/docs/Column.md#celldatagetter
+    // props: { columnData, dataKey, rowData }
+    const { rowData, dataKey } = props
+    return get(rowData, dataKey, 'N/A')
+  }
+
+  cellRenderer = (props) => {
+    // See: https://github.com/bvaughn/react-virtualized/blob/master/docs/Column.md#cellrenderer
+    // props: { cellData, columnData, columnIndex, dataKey, isScrolling, rowData, rowIndex }
+    const { cellData, rowIndex } = props
+    const { dataKey, onChange, dropDownProps, options  } = this.props
+
+    return (
+      <DropdownCell
+        name={dataKey}
+        onChange={onChange}
+        options={options}
+        content={cellData}
+        rowIndex={rowIndex}
+        {...dropDownProps}
+      />
+    )
+  }
+
+  headerRenderer = (props) => {
+    // See: https://github.com/bvaughn/react-virtualized/blob/master/docs/Column.md#headerrenderer
+    // props: { columnData, dataKey, disableSort, label, sortBy, sortDirection, }
+    const { label } = props
+    return <p>{label}</p>
+  }
+
+  render() {
+    const { label, dataKey, width } = this.props
+
+    return (
+      <Column
+        label={label}
+        dataKey={dataKey}
+        width={width}
+        cellDataGetter={this.cellDataGetter}
+        cellRenderer={this.cellRenderer}
+        headerRenderer={this.headerRenderer}
+      />
+    )
+  }
+}
+
+
+export default DropdownColumn

--- a/src/lib/molecules/table-columns/dropdown-column.test.js
+++ b/src/lib/molecules/table-columns/dropdown-column.test.js
@@ -1,0 +1,73 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+
+import { DropdownCell } from 'LibIndex'
+import DropdownColumn from './dropdown-column'
+
+
+describe('Test DropdownColumn', () => {
+  it('cellDataGetter returns expected content', () => {
+    const rowData = { name: 'mike', 'value': '1' }
+    const dataKey = 'name'
+    const element = (
+      <DropdownColumn
+        label="test"
+        dataKey={dataKey}
+        width={100}
+        options={[{ key: 'key2', value: 2, text: '2'}]}
+        onChange={jest.fn()}
+      />
+    )
+    const wrapper = shallow(element)
+    expect(wrapper.find('Column').props().cellDataGetter({ rowData, dataKey }))
+      .toEqual('mike')
+  })
+
+  it('cellRenderer returns expected content', () => {
+    const cellData = 'mike'
+    const rowIndex = 1
+    const onChange = jest.fn()
+    const element = (
+      <DropdownColumn
+        label="test"
+        dataKey="test"
+        width={100}
+        options={[{ key: 'key2', value: 2, text: '2'}]}
+        onChange={onChange}
+      />
+    )
+    const wrapper = shallow(element)
+    const cellElement = (
+      <DropdownCell
+        as="div"
+        name="test"
+        onChange={onChange}
+        options={[{ key: 'key2', value: 2, text: '2'}]}
+        content="mike"
+        rowIndex={1}
+        fluid={false}
+        multiple={false}
+        selection={true}
+        search={true}
+      />
+    )
+    expect(wrapper.find('Column').props().cellRenderer({ cellData, rowIndex }))
+      .toEqual(cellElement)
+  })
+
+  it('headerRenderer returns expected content', () => {
+    const label = 'Mike Column'
+    const element = (
+      <DropdownColumn
+        label="test"
+        dataKey="test"
+        width={100}
+        options={[{ key: 'key2', value: 2, text: '2'}]}
+        onChange={jest.fn()}
+      />
+    )
+    const wrapper = shallow(element)
+    expect(wrapper.find('Column').props().headerRenderer({label }))
+      .toEqual(<p>Mike Column</p>)
+  })
+})

--- a/src/lib/molecules/table-columns/link-column.js
+++ b/src/lib/molecules/table-columns/link-column.js
@@ -1,0 +1,69 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Column } from 'react-virtualized'
+import { get, omit } from 'lodash'
+
+import { LinkCell } from 'LibIndex'
+
+
+// See: https://github.com/bvaughn/react-virtualized/pull/748
+// Note: Facebook argues against inheritance https://reactjs.org/docs/composition-vs-inheritance.html
+// But Table won't accept anything other than type of Column
+// Submitted an issue shown here: https://github.com/bvaughn/react-virtualized/issues/898
+
+
+class LinkColumn extends React.Component {
+  constructor(props){
+    super(props)
+
+    this.prototype = Column
+  }
+
+  cellDataGetter = (props) => {
+    // See: https://github.com/bvaughn/react-virtualized/blob/master/docs/Column.md#celldatagetter
+    // props: { columnData, dataKey, rowData }
+    const { rowData, dataKey } = props
+    return get(rowData, dataKey, 'N/A')
+  }
+
+  cellRenderer = (props) => {
+    // See: https://github.com/bvaughn/react-virtualized/blob/master/docs/Column.md#cellrenderer
+    // props: { cellData, columnData, columnIndex, dataKey, isScrolling, rowData, rowIndex }
+    const { cellData, rowIndex } = props
+    const { as, path } = this.props
+
+    return (
+      <LinkCell
+        linkAs={as}
+        path={path}
+        content={cellData}
+        rowIndex={rowIndex}
+      />
+    )
+  }
+
+  headerRenderer = (props) => {
+    // See: https://github.com/bvaughn/react-virtualized/blob/master/docs/Column.md#headerrenderer
+    // props: { columnData, dataKey, disableSort, label, sortBy, sortDirection, }
+    const { label } = props
+    return <p>{label}</p>
+  }
+
+  render() {
+    const { label, dataKey, width } = this.props
+
+    return (
+      <Column
+        label={label}
+        dataKey={dataKey}
+        width={width}
+        cellDataGetter={this.cellDataGetter}
+        cellRenderer={this.cellRenderer}
+        headerRenderer={this.headerRenderer}
+      />
+    )
+  }
+}
+
+
+export default LinkColumn

--- a/src/lib/molecules/table-columns/link-column.test.js
+++ b/src/lib/molecules/table-columns/link-column.test.js
@@ -1,0 +1,58 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+
+import { LinkCell } from 'LibIndex'
+import LinkColumn from './link-column'
+
+
+describe('Test LinkColumn', () => {
+  it('cellDataGetter returns expected content', () => {
+    const rowData = { name: 'mike', 'value': '1' }
+    const dataKey = 'name'
+    const element = (
+      <LinkColumn
+        label="test"
+        dataKey={dataKey}
+        width={100}
+        linkAs="a"
+        path="http://www.google.com"
+      />
+    )
+    const wrapper = shallow(element)
+    expect(wrapper.find('Column').props().cellDataGetter({ rowData, dataKey }))
+      .toEqual('mike')
+  })
+
+  it('cellRenderer returns expected content', () => {
+    const cellData = 'mike'
+    const rowIndex = 1
+    const element = (
+      <LinkColumn
+        label="test"
+        dataKey="test"
+        width={100}
+        linkAs="a"
+        path="http://www.google.com"
+      />
+    )
+    const wrapper = shallow(element)
+    expect(wrapper.find('Column').props().cellRenderer({ cellData, rowIndex }))
+      .toEqual(<LinkCell as="div" linkAs="a" path="http://www.google.com" content="mike" rowIndex={1} />)
+  })
+
+  it('headerRenderer returns expected content', () => {
+    const label = 'Mike Column'
+    const element = (
+      <LinkColumn
+        label={label}
+        dataKey="test"
+        width={100}
+        linkAs="a"
+        path="http://www.google.com"
+      />
+    )
+    const wrapper = shallow(element)
+    expect(wrapper.find('Column').props().headerRenderer({label }))
+      .toEqual(<p>Mike Column</p>)
+  })
+})

--- a/src/lib/molecules/table-columns/text-column.js
+++ b/src/lib/molecules/table-columns/text-column.js
@@ -1,0 +1,58 @@
+import React from 'react'
+import { Column } from 'react-virtualized'
+import { get } from 'lodash'
+
+import { TextCell } from 'LibIndex'
+
+
+// See: https://github.com/bvaughn/react-virtualized/pull/748
+// Note: Facebook argues against inheritance https://reactjs.org/docs/composition-vs-inheritance.html
+// But Table won't accept anything other than type of Column
+// Submitted an issue shown here: https://github.com/bvaughn/react-virtualized/issues/898
+
+
+class TextColumn extends Column {
+  cellDataGetter = (props) => {
+    // See: https://github.com/bvaughn/react-virtualized/blob/master/docs/Column.md#celldatagetter
+    // props: { columnData, dataKey, rowData }
+    const { rowData, dataKey } = props
+    return get(rowData, dataKey, 'N/A')
+  }
+
+  cellRenderer = (props) => {
+    // See: https://github.com/bvaughn/react-virtualized/blob/master/docs/Column.md#cellrenderer
+    // props: { cellData, columnData, columnIndex, dataKey, isScrolling, rowData, rowIndex }
+    const { cellData, rowIndex } = props
+    return (
+      <TextCell
+        content={cellData}
+        rowIndex={rowIndex}
+      />
+    )
+  }
+
+  headerRenderer = (props) => {
+    // See: https://github.com/bvaughn/react-virtualized/blob/master/docs/Column.md#headerrenderer
+    // props: { columnData, dataKey, disableSort, label, sortBy, sortDirection, }
+    const { label } = props
+    return <p>{label}</p>
+  }
+
+  render() {
+    const { label, dataKey, width } = this.props
+
+    return (
+      <Column
+        label={label}
+        dataKey={dataKey}
+        width={width}
+        cellDataGetter={this.cellDataGetter}
+        cellRenderer={this.cellRenderer}
+        headerRenderer={this.headerRenderer}
+      />
+    )
+  }
+}
+
+
+export default TextColumn

--- a/src/lib/molecules/table-columns/text-column.test.js
+++ b/src/lib/molecules/table-columns/text-column.test.js
@@ -1,0 +1,53 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+
+import { TextCell } from 'LibIndex'
+import TextColumn from './text-column'
+
+
+describe('Test TextColumn', () => {
+  it('cellDataGetter returns expected content', () => {
+    const rowData = { name: 'mike', 'value': '1' }
+    const dataKey = 'name'
+    const element = (
+      <TextColumn
+        label="test"
+        dataKey={dataKey}
+        width={100}
+      />
+    )
+    const wrapper = shallow(element)
+    expect(wrapper.find('Column').props().cellDataGetter({ rowData, dataKey }))
+      .toEqual('mike')
+  })
+
+
+  it('cellRenderer returns expected content', () => {
+    const cellData = 'mike'
+    const rowIndex = 1
+    const element = (
+      <TextColumn
+        label="test"
+        dataKey="test"
+        width={100}
+      />
+    )
+    const wrapper = shallow(element)
+    expect(wrapper.find('Column').props().cellRenderer({ cellData, rowIndex }))
+      .toEqual(<TextCell as="div" content="mike" rowIndex={1} />)
+  })
+
+  it('headerRenderer returns expected content', () => {
+    const label = 'Mike Column'
+    const element = (
+      <TextColumn
+        label={label}
+        dataKey="test"
+        width={100}
+      />
+    )
+    const wrapper = shallow(element)
+    expect(wrapper.find('Column').props().headerRenderer({label }))
+      .toEqual(<p>Mike Column</p>)
+  })
+})


### PR DESCRIPTION
Dear Maintainers,

Please accept this PR that addresses the following issues:
+ *Added Custom Cell classes for use in Tables*
+ *Added Custom Column classes for use specifically in `react-virtualized` tables*

Notes:
+ Currently `Table` in `react-virtualized` do not accept these custom columns.  There is a [pending PR](https://github.com/bvaughn/react-virtualized/pull/899) to allow for this.  If not, we can create a fork.

Testing Done:
+ Unittests are included for all elements
