### PR TITLE
Refactored columns to work with react-virtualized by using columnData

### DIFF
--- a/src/demo/components/BigDataTableExample.js
+++ b/src/demo/components/BigDataTableExample.js
@@ -2,28 +2,64 @@ import React from 'react'
 import { Column } from 'react-virtualized'
 import { Grid } from 'semantic-ui-react'
 
-import { BigDataTable } from 'LibIndex'
+import {
+  BigDataTable,
+  CheckboxColumn,
+  DropdownColumn,
+  LinkColumn,
+  TextColumn,
+} from 'LibIndex'
 
 
 const list = Array.from(new Array(30), (x,i) => ({
   base: 'Base',
   checkbox: true,
   dropdown: 1,
-  link: 'http://www.google.com',
+  link: 'link',
   text: 'Text',
 }))
 
 
 const ExampleInfiniteTable = () => (
   <Grid>
-    <Grid.Column width={12}>
+    <Grid.Column width={16}>
       <BigDataTable
         data={list}
         height={400}
+        rowHeight={65}
+        headerTextAlign="left"
       >
         <Column
           label="Base Column"
           dataKey="base"
+          width={150}
+        />
+        <CheckboxColumn
+          label="Checkbox Column"
+          dataKey="checkbox"
+          width={150}
+          columnData={{ onChange: (props) => alert(JSON.stringify(props)) }}
+        />
+        <DropdownColumn
+          label="Dropdown Column"
+          dataKey="dropdown"
+          width={350}
+          columnData={{
+            onChange: (props) => alert(JSON.stringify(props)),
+            options: [{ key: 1, value: 1, text: '1' }],
+          }}
+        />
+        <LinkColumn
+          label="Link Column"
+          dataKey="link"
+          width={150}
+          columnData={{
+            urlBuilder: (cellData) => `https://www.google.com/search?q=${cellData}`
+          }}
+        />
+        <TextColumn
+          label="Text Column"
+          dataKey="text"
           width={150}
         />
       </BigDataTable>

--- a/src/lib/molecules/table-columns/checkbox-column.js
+++ b/src/lib/molecules/table-columns/checkbox-column.js
@@ -11,59 +11,56 @@ import { CheckboxCell } from 'LibIndex'
 // But Table won't accept anything other than type of Column
 // Submitted an issue shown here: https://github.com/bvaughn/react-virtualized/issues/898
 
+const cellDataGetter = (props) => {
+  // See: https://github.com/bvaughn/react-virtualized/blob/master/docs/Column.md#celldatagetter
+  // props: { columnData, dataKey, rowData }
+  const { rowData, dataKey } = props
+  return get(rowData, dataKey, 'N/A')
+}
+
+const cellRenderer = (props) => {
+  // See: https://github.com/bvaughn/react-virtualized/blob/master/docs/Column.md#cellrenderer
+  // props: { cellData, columnData, columnIndex, dataKey, isScrolling, rowData, rowIndex }
+  const { cellData, columnData, rowIndex } = props
+  const { onChange } = columnData
+
+  return (
+    <CheckboxCell
+      onChange={onChange}
+      content={cellData}
+      rowIndex={rowIndex}
+    />
+  )
+}
+
+const headerRenderer = (props) => {
+  // See: https://github.com/bvaughn/react-virtualized/blob/master/docs/Column.md#headerrenderer
+  // props: { columnData, dataKey, disableSort, label, sortBy, sortDirection, }
+  const { label } = props
+  return <p>{label}</p>
+}
+
 
 class CheckboxColumn extends Column {
   static propTypes = {
     ...Column.propTypes,
-    onChange: PropTypes.func.isRequired,
+    cellDataGetter: PropTypes.func.isRequired,
+    cellRenderer: PropTypes.func.isRequired,
+    headerRenderer: PropTypes.func.isRequired,
+    columnData: PropTypes.shape({
+      onChange: PropTypes.func.isRequired,
+    }).isRequired,
   }
 
   static defaultProps = {
     ...Column.defaultProps,
-  }
-
-  cellDataGetter = (props) => {
-    // See: https://github.com/bvaughn/react-virtualized/blob/master/docs/Column.md#celldatagetter
-    // props: { columnData, dataKey, rowData }
-    const { rowData, dataKey } = props
-    return get(rowData, dataKey, 'N/A')
-  }
-
-  cellRenderer = (props) => {
-    // See: https://github.com/bvaughn/react-virtualized/blob/master/docs/Column.md#cellrenderer
-    // props: { cellData, columnData, columnIndex, dataKey, isScrolling, rowData, rowIndex }
-    const { cellData, rowIndex } = props
-    const { onChange } = this.props
-
-    return (
-      <CheckboxCell
-        onChange={onChange}
-        content={cellData}
-        rowIndex={rowIndex}
-      />
-    )
-  }
-
-  headerRenderer = (props) => {
-    // See: https://github.com/bvaughn/react-virtualized/blob/master/docs/Column.md#headerrenderer
-    // props: { columnData, dataKey, disableSort, label, sortBy, sortDirection, }
-    const { label } = props
-    return <p>{label}</p>
+    cellDataGetter: cellDataGetter,
+    cellRenderer: cellRenderer,
+    headerRenderer: headerRenderer,
   }
 
   render() {
-    const { label, dataKey, width } = this.props
-
-    return (
-      <Column
-        label={label}
-        dataKey={dataKey}
-        width={width}
-        cellDataGetter={this.cellDataGetter}
-        cellRenderer={this.cellRenderer}
-        headerRenderer={this.headerRenderer}
-      />
-    )
+    return <Column {...this.props} />
   }
 }
 

--- a/src/lib/molecules/table-columns/checkbox-column.test.js
+++ b/src/lib/molecules/table-columns/checkbox-column.test.js
@@ -14,7 +14,7 @@ describe('Test CheckboxColumn', () => {
         label="test"
         dataKey={dataKey}
         width={100}
-        onChange={jest.fn()}
+        columnData={{onChange: jest.fn()}}
       />
     )
     const wrapper = shallow(element)
@@ -24,18 +24,20 @@ describe('Test CheckboxColumn', () => {
 
   it('cellRenderer returns expected content', () => {
     const cellData = 'mike'
+    const dataKey = 'name'
     const rowIndex = 1
     const onChange = jest.fn()
+    const columnData= { onChange: onChange }
     const element = (
       <CheckboxColumn
         label="test"
-        dataKey="test"
+        dataKey={dataKey}
         width={100}
-        onChange={onChange}
+        columnData={columnData}
       />
     )
     const wrapper = shallow(element)
-    expect(wrapper.find('Column').props().cellRenderer({ cellData, rowIndex }))
+    expect(wrapper.find('Column').props().cellRenderer({ dataKey, columnData, cellData, rowIndex }))
       .toEqual(<CheckboxCell as="div" onChange={onChange} content="mike" rowIndex={1} />)
   })
 
@@ -46,7 +48,7 @@ describe('Test CheckboxColumn', () => {
         label={label}
         dataKey="test"
         width={100}
-        onChange={jest.fn()}
+        columnData={{onChange: jest.fn()}}
       />
     )
     const wrapper = shallow(element)

--- a/src/lib/molecules/table-columns/dropdown-column.js
+++ b/src/lib/molecules/table-columns/dropdown-column.js
@@ -11,90 +11,88 @@ import { DropdownCell } from 'LibIndex'
 // But Table won't accept anything other than type of Column
 // Submitted an issue shown here: https://github.com/bvaughn/react-virtualized/issues/898
 
+const cellDataGetter = (props) => {
+  // See: https://github.com/bvaughn/react-virtualized/blob/master/docs/Column.md#celldatagetter
+  // props: { columnData, dataKey, rowData }
+  const { rowData, dataKey } = props
+  return get(rowData, dataKey, 'N/A')
+}
+
+const cellRenderer = (props) => {
+  // See: https://github.com/bvaughn/react-virtualized/blob/master/docs/Column.md#cellrenderer
+  // props: { cellData, columnData, columnIndex, dataKey, isScrolling, rowData, rowIndex }
+  const { cellData, columnData, dataKey, rowIndex } = props
+
+  return (
+    <DropdownCell
+      name={dataKey}
+      content={cellData}
+      rowIndex={rowIndex}
+      {...columnData}
+    />
+  )
+}
+
+const headerRenderer = (props) => {
+  // See: https://github.com/bvaughn/react-virtualized/blob/master/docs/Column.md#headerrenderer
+  // props: { columnData, dataKey, disableSort, label, sortBy, sortDirection, }
+  const { label } = props
+  return <p>{label}</p>
+}
+
 
 class DropdownColumn extends Column {
   static propTypes = {
     ...Column.propTypes,
-    onChange: PropTypes.func.isRequired,
-    dropDownProps: PropTypes.object,
-    options: PropTypes.arrayOf(
-      PropTypes.shape({
-        key: PropTypes.oneOfType([
-          PropTypes.string,
-          PropTypes.number,
-        ]).isRequired,
-        value: PropTypes.oneOfType([
-          PropTypes.string,
-          PropTypes.number,
-        ]).isRequired,
-        text: PropTypes.oneOfType([
-          PropTypes.string,
-          PropTypes.number,
-        ]).isRequired,
-        content: PropTypes.oneOfType([
-          PropTypes.string,
-          PropTypes.number,
-          PropTypes.element,
-        ]),
-      })
-    ).isRequired,
+    className: PropTypes.string,
+    cellDataGetter: PropTypes.func.isRequired,
+    cellRenderer: PropTypes.func.isRequired,
+    headerRenderer: PropTypes.func.isRequired,
+    columnData: PropTypes.shape({
+      onChange: PropTypes.func.isRequired,
+      options: PropTypes.arrayOf(
+        PropTypes.shape({
+          key: PropTypes.oneOfType([
+            PropTypes.string,
+            PropTypes.number,
+          ]).isRequired,
+          value: PropTypes.oneOfType([
+            PropTypes.string,
+            PropTypes.number,
+          ]).isRequired,
+          text: PropTypes.oneOfType([
+            PropTypes.string,
+            PropTypes.number,
+          ]).isRequired,
+          content: PropTypes.oneOfType([
+            PropTypes.string,
+            PropTypes.number,
+            PropTypes.element,
+          ]),
+        }),
+      ).isRequired,
+      dropDownProps: PropTypes.object,
+    }).isRequired,
   }
 
   static defaultProps = {
     ...Column.defaultProps,
-    dropDownProps: {
-      fluid: false,
-      multiple: false,
-      selection: true,
-      search: true,
+    className: 'dropdown col',
+    cellDataGetter: cellDataGetter,
+    cellRenderer: cellRenderer,
+    headerRenderer: headerRenderer,
+    columnData: {
+      dropDownProps: {
+        fluid: false,
+        multiple: false,
+        selection: true,
+        search: true,
+      }
     },
   }
 
-  cellDataGetter = (props) => {
-    // See: https://github.com/bvaughn/react-virtualized/blob/master/docs/Column.md#celldatagetter
-    // props: { columnData, dataKey, rowData }
-    const { rowData, dataKey } = props
-    return get(rowData, dataKey, 'N/A')
-  }
-
-  cellRenderer = (props) => {
-    // See: https://github.com/bvaughn/react-virtualized/blob/master/docs/Column.md#cellrenderer
-    // props: { cellData, columnData, columnIndex, dataKey, isScrolling, rowData, rowIndex }
-    const { cellData, rowIndex } = props
-    const { dataKey, onChange, dropDownProps, options  } = this.props
-
-    return (
-      <DropdownCell
-        name={dataKey}
-        onChange={onChange}
-        options={options}
-        content={cellData}
-        rowIndex={rowIndex}
-        {...dropDownProps}
-      />
-    )
-  }
-
-  headerRenderer = (props) => {
-    // See: https://github.com/bvaughn/react-virtualized/blob/master/docs/Column.md#headerrenderer
-    // props: { columnData, dataKey, disableSort, label, sortBy, sortDirection, }
-    const { label } = props
-    return <p>{label}</p>
-  }
-
   render() {
-    const { label, dataKey, width } = this.props
-
-    return (
-      <Column
-        label={label}
-        dataKey={dataKey}
-        width={width}
-        cellDataGetter={this.cellDataGetter}
-        cellRenderer={this.cellRenderer}
-        headerRenderer={this.headerRenderer}
-      />
-    )
+    return <Column {...this.props} />
   }
 }
 

--- a/src/lib/molecules/table-columns/dropdown-column.test.js
+++ b/src/lib/molecules/table-columns/dropdown-column.test.js
@@ -14,8 +14,10 @@ describe('Test DropdownColumn', () => {
         label="test"
         dataKey={dataKey}
         width={100}
-        options={[{ key: 'key2', value: 2, text: '2'}]}
-        onChange={jest.fn()}
+        columnData={{
+          options: [{ key: 'key2', value: 2, text: '2'}],
+          onChange: jest.fn(),
+        }}
       />
     )
     const wrapper = shallow(element)
@@ -25,15 +27,19 @@ describe('Test DropdownColumn', () => {
 
   it('cellRenderer returns expected content', () => {
     const cellData = 'mike'
+    const dataKey = 'test'
     const rowIndex = 1
     const onChange = jest.fn()
+    const columnData = {
+      options: [{ key: 'key2', value: 2, text: '2'}],
+      onChange: onChange,
+    }
     const element = (
       <DropdownColumn
         label="test"
-        dataKey="test"
+        dataKey={dataKey}
         width={100}
-        options={[{ key: 'key2', value: 2, text: '2'}]}
-        onChange={onChange}
+        columnData={columnData}
       />
     )
     const wrapper = shallow(element)
@@ -45,13 +51,15 @@ describe('Test DropdownColumn', () => {
         options={[{ key: 'key2', value: 2, text: '2'}]}
         content="mike"
         rowIndex={1}
-        fluid={false}
-        multiple={false}
-        selection={true}
-        search={true}
+        dropDownProps={{
+          fluid: false,
+          multiple: false,
+          selection: true,
+          search: true,
+        }}
       />
     )
-    expect(wrapper.find('Column').props().cellRenderer({ cellData, rowIndex }))
+    expect(wrapper.find('Column').props().cellRenderer({ dataKey, columnData, cellData, rowIndex }))
       .toEqual(cellElement)
   })
 
@@ -62,8 +70,10 @@ describe('Test DropdownColumn', () => {
         label="test"
         dataKey="test"
         width={100}
-        options={[{ key: 'key2', value: 2, text: '2'}]}
-        onChange={jest.fn()}
+        columnData={{
+          options: [{ key: 'key2', value: 2, text: '2'}],
+          onChange: jest.fn(),
+        }}
       />
     )
     const wrapper = shallow(element)

--- a/src/lib/molecules/table-columns/link-column.js
+++ b/src/lib/molecules/table-columns/link-column.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { Column } from 'react-virtualized'
-import { get, omit } from 'lodash'
+import { get } from 'lodash'
 
 import { LinkCell } from 'LibIndex'
 
@@ -11,57 +11,65 @@ import { LinkCell } from 'LibIndex'
 // But Table won't accept anything other than type of Column
 // Submitted an issue shown here: https://github.com/bvaughn/react-virtualized/issues/898
 
+const cellDataGetter = (props) => {
+  // See: https://github.com/bvaughn/react-virtualized/blob/master/docs/Column.md#celldatagetter
+  // props: { columnData, dataKey, rowData }
+  const { rowData, dataKey } = props
+  return get(rowData, dataKey, 'N/A')
+}
 
-class LinkColumn extends React.Component {
-  constructor(props){
-    super(props)
+const cellRenderer = (props) => {
+  // See: https://github.com/bvaughn/react-virtualized/blob/master/docs/Column.md#cellrenderer
+  // props: { cellData, columnData, columnIndex, dataKey, isScrolling, rowData, rowIndex }
+  const { cellData, columnData, rowIndex } = props
+  const { as, urlBuilder } = columnData
+  const path = urlBuilder(cellData)
 
-    this.prototype = Column
+  return (
+    <LinkCell
+      linkAs={as}
+      path={path}
+      content={cellData}
+      rowIndex={rowIndex}
+    />
+  )
+}
+
+const headerRenderer = (props) => {
+  // See: https://github.com/bvaughn/react-virtualized/blob/master/docs/Column.md#headerrenderer
+  // props: { columnData, dataKey, disableSort, label, sortBy, sortDirection, }
+  const { label } = props
+  return <p>{label}</p>
+}
+
+
+class LinkColumn extends Column {
+  static propTypes = {
+    ...Column.propTypes,
+    cellDataGetter: PropTypes.func.isRequired,
+    cellRenderer: PropTypes.func.isRequired,
+    headerRenderer: PropTypes.func.isRequired,
+    columnData: PropTypes.shape({
+      as: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.func,
+      ]),
+      urlBuilder: PropTypes.func.isRequired,
+    }),
   }
 
-  cellDataGetter = (props) => {
-    // See: https://github.com/bvaughn/react-virtualized/blob/master/docs/Column.md#celldatagetter
-    // props: { columnData, dataKey, rowData }
-    const { rowData, dataKey } = props
-    return get(rowData, dataKey, 'N/A')
-  }
-
-  cellRenderer = (props) => {
-    // See: https://github.com/bvaughn/react-virtualized/blob/master/docs/Column.md#cellrenderer
-    // props: { cellData, columnData, columnIndex, dataKey, isScrolling, rowData, rowIndex }
-    const { cellData, rowIndex } = props
-    const { as, path } = this.props
-
-    return (
-      <LinkCell
-        linkAs={as}
-        path={path}
-        content={cellData}
-        rowIndex={rowIndex}
-      />
-    )
-  }
-
-  headerRenderer = (props) => {
-    // See: https://github.com/bvaughn/react-virtualized/blob/master/docs/Column.md#headerrenderer
-    // props: { columnData, dataKey, disableSort, label, sortBy, sortDirection, }
-    const { label } = props
-    return <p>{label}</p>
+  static defaultProps = {
+    ...Column.defaultProps,
+    cellDataGetter: cellDataGetter,
+    cellRenderer: cellRenderer,
+    headerRenderer: headerRenderer,
+    columnData: {
+      as: 'a',
+    }
   }
 
   render() {
-    const { label, dataKey, width } = this.props
-
-    return (
-      <Column
-        label={label}
-        dataKey={dataKey}
-        width={width}
-        cellDataGetter={this.cellDataGetter}
-        cellRenderer={this.cellRenderer}
-        headerRenderer={this.headerRenderer}
-      />
-    )
+    return <Column {...this.props} />
   }
 }
 

--- a/src/lib/molecules/table-columns/link-column.test.js
+++ b/src/lib/molecules/table-columns/link-column.test.js
@@ -9,13 +9,13 @@ describe('Test LinkColumn', () => {
   it('cellDataGetter returns expected content', () => {
     const rowData = { name: 'mike', 'value': '1' }
     const dataKey = 'name'
+    const urlBuilder = jest.fn()
     const element = (
       <LinkColumn
         label="test"
         dataKey={dataKey}
         width={100}
-        linkAs="a"
-        path="http://www.google.com"
+        columnData={{ urlBuilder }}
       />
     )
     const wrapper = shallow(element)
@@ -26,29 +26,49 @@ describe('Test LinkColumn', () => {
   it('cellRenderer returns expected content', () => {
     const cellData = 'mike'
     const rowIndex = 1
+    const urlBuilder = (cellData) => `http://example.com/${cellData}`
+    const columnData = { urlBuilder }
     const element = (
       <LinkColumn
         label="test"
         dataKey="test"
         width={100}
-        linkAs="a"
-        path="http://www.google.com"
+        columnData={columnData}
       />
     )
     const wrapper = shallow(element)
-    expect(wrapper.find('Column').props().cellRenderer({ cellData, rowIndex }))
-      .toEqual(<LinkCell as="div" linkAs="a" path="http://www.google.com" content="mike" rowIndex={1} />)
+    expect(wrapper.find('Column').props().cellRenderer({ columnData, cellData, rowIndex }))
+      .toEqual(<LinkCell as="div" linkAs="a" path="http://example.com/mike" content="mike" rowIndex={1} />)
+  })
+
+  it('urlBuilder is called when cellRenderer is fired' , () => {
+    const cellData = 'mike'
+    const rowIndex = 1
+    const urlBuilder = jest.fn()
+    urlBuilder.mockReturnValue('http://example.com/mike')
+    const columnData = { urlBuilder }
+    const element = (
+      <LinkColumn
+        label="test"
+        dataKey="test"
+        width={100}
+        columnData={columnData}
+      />
+    )
+    const wrapper = shallow(element)
+    wrapper.find('Column').props().cellRenderer({ columnData, cellData, rowIndex })
+    expect(urlBuilder).toHaveBeenCalledWith(cellData)
   })
 
   it('headerRenderer returns expected content', () => {
     const label = 'Mike Column'
+    const urlBuilder = (cellData) => `http://example.com/${cellData}`
     const element = (
       <LinkColumn
         label={label}
         dataKey="test"
         width={100}
-        linkAs="a"
-        path="http://www.google.com"
+        columnData={{ urlBuilder }}
       />
     )
     const wrapper = shallow(element)

--- a/src/lib/molecules/table-columns/text-column.js
+++ b/src/lib/molecules/table-columns/text-column.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import { Column } from 'react-virtualized'
 import { get } from 'lodash'
 
@@ -10,47 +11,51 @@ import { TextCell } from 'LibIndex'
 // But Table won't accept anything other than type of Column
 // Submitted an issue shown here: https://github.com/bvaughn/react-virtualized/issues/898
 
+const cellDataGetter = (props) => {
+  // See: https://github.com/bvaughn/react-virtualized/blob/master/docs/Column.md#celldatagetter
+  // props: { columnData, dataKey, rowData }
+  const { rowData, dataKey } = props
+  return get(rowData, dataKey, 'N/A')
+}
+
+const cellRenderer = (props) => {
+  // See: https://github.com/bvaughn/react-virtualized/blob/master/docs/Column.md#cellrenderer
+  // props: { cellData, columnData, columnIndex, dataKey, isScrolling, rowData, rowIndex }
+  const { cellData, rowIndex } = props
+
+  return (
+    <TextCell
+      content={cellData}
+      rowIndex={rowIndex}
+    />
+  )
+}
+
+const headerRenderer = (props) => {
+  // See: https://github.com/bvaughn/react-virtualized/blob/master/docs/Column.md#headerrenderer
+  // props: { columnData, dataKey, disableSort, label, sortBy, sortDirection, }
+  const { label } = props
+  return <p>{label}</p>
+}
+
 
 class TextColumn extends Column {
-  cellDataGetter = (props) => {
-    // See: https://github.com/bvaughn/react-virtualized/blob/master/docs/Column.md#celldatagetter
-    // props: { columnData, dataKey, rowData }
-    const { rowData, dataKey } = props
-    return get(rowData, dataKey, 'N/A')
+  static propTypes = {
+    ...Column.propTypes,
+    cellDataGetter: PropTypes.func.isRequired,
+    cellRenderer: PropTypes.func.isRequired,
+    headerRenderer: PropTypes.func.isRequired,
   }
 
-  cellRenderer = (props) => {
-    // See: https://github.com/bvaughn/react-virtualized/blob/master/docs/Column.md#cellrenderer
-    // props: { cellData, columnData, columnIndex, dataKey, isScrolling, rowData, rowIndex }
-    const { cellData, rowIndex } = props
-    return (
-      <TextCell
-        content={cellData}
-        rowIndex={rowIndex}
-      />
-    )
-  }
-
-  headerRenderer = (props) => {
-    // See: https://github.com/bvaughn/react-virtualized/blob/master/docs/Column.md#headerrenderer
-    // props: { columnData, dataKey, disableSort, label, sortBy, sortDirection, }
-    const { label } = props
-    return <p>{label}</p>
+  static defaultProps = {
+    ...Column.defaultProps,
+    cellDataGetter: cellDataGetter,
+    cellRenderer: cellRenderer,
+    headerRenderer: headerRenderer,
   }
 
   render() {
-    const { label, dataKey, width } = this.props
-
-    return (
-      <Column
-        label={label}
-        dataKey={dataKey}
-        width={width}
-        cellDataGetter={this.cellDataGetter}
-        cellRenderer={this.cellRenderer}
-        headerRenderer={this.headerRenderer}
-      />
-    )
+    return <Column {...this.props} />
   }
 }
 

--- a/src/stylesheets/partials/tables.scss
+++ b/src/stylesheets/partials/tables.scss
@@ -9,6 +9,7 @@
   border: 1px solid #e0e0e0;
   border-radius: 5px;
   font-family: $font-family;
+  overflow: visible;
 }
 
 .genomix.big-data.table .header.row {
@@ -46,4 +47,13 @@
   justify-content: center;
   font-size: 1em;
   color: #bdbdbd;
+}
+
+// Deal with drop down columns
+.genomix.big-data.table .dropdown.col[style] {
+  overflow: visible!important;
+}
+
+.ReactVirtualized__Table__row[style] {
+  overflow: visible!important;
 }


### PR DESCRIPTION
Dear Maintainers,

Please accept this PR that addresses the following issues:
+ *Used `columnData` prop in `react-virtualized` `Column` to extend Column and create custom columns*

Testing Done:
+ Unittests are included
