### PR TITLE
Changed Travis from NPM to Yarn

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,16 +3,10 @@ language: node_js
 node_js:
  - "node"
 
-before_install: npm install greenkeeper-lockfile@1 --global
-
-before_script: greenkeeper-lockfile-update
-
 install:
-  - npm install codecov --global
-  - npm install
+  - yarn global add codecov
+  - yarn install
 
 script:
- - npm run test
+ - yarn run test --maxWorkers=4
  - codecov
-
-after_script: greenkeeper-lockfile-upload


### PR DESCRIPTION
removed greenkeeper lock file

Dear Maintainers,

Please accept this PR that addresses the following issues:
+ *Moved CI to use yarn again instead of NPM*
+ *Removed greenkeeper lock file*
+ *added `-maxWorkers=4` to jest testing.  See [here](https://github.com/facebook/jest/issues/3855)*

