### PR TITLE
Resolved #146 - Target in TurnAroundTimeProgress is no longer required

### DIFF
--- a/src/lib/atoms/progress-bars/turn-around-time-progress.js
+++ b/src/lib/atoms/progress-bars/turn-around-time-progress.js
@@ -54,7 +54,7 @@ class TurnAroundTimeProgress extends React.PureComponent {
 
 
 TurnAroundTimeProgress.propTypes = {
-  target: PropTypes.number.isRequired,
+  target: PropTypes.number,
   start: PropTypes.string,
   signout: PropTypes.string,
 }


### PR DESCRIPTION
Dear Maintainers,

Please accept this PR that addresses the following issues:
+ *#146*
