### PR TITLE
Convert to Stateless components instead of PureComponents for simple components

### DIFF
--- a/src/demo/components/Modals.js
+++ b/src/demo/components/Modals.js
@@ -48,7 +48,7 @@ class Modals extends React.PureComponent {
     return (
       <Grid padded centered>
         <Grid.Column width={6}>
-          <GenomiX.SaveFormModal
+          <GenomiX.FormModal
             className="example-modal"
             formId="example"
             trigger={<GenomiX.Button icon="tasks" content="Open"/>}
@@ -76,7 +76,7 @@ class Modals extends React.PureComponent {
               control={Dropdown}
               defaultValue="3"
             />
-          </GenomiX.SaveFormModal>
+          </GenomiX.FormModal>
         </Grid.Column>
       </Grid>
     )

--- a/src/lib/atoms/buttons/Button.js
+++ b/src/lib/atoms/buttons/Button.js
@@ -6,19 +6,17 @@ import cx from 'classnames'
 import getUnhandledProps from 'LibSrc/helpers/getUnhandledProps'
 
 
-class Button extends React.PureComponent {
-  render() {
-    const buttonProps = getUnhandledProps(Button, this.props)
-    const { color, icon } = this.props
+const Button = props => {
+  const buttonProps = getUnhandledProps(Button, props)
+  const { className, color, icon } = props
 
-    return (
-      <SemanticButton
-        { ...buttonProps }
-        className={cx(this.props.className, 'genomix', color)}
-        icon={icon}
-      />
-    )
-  }
+  return (
+    <SemanticButton
+      { ...buttonProps }
+      className={cx(className, 'genomix', color)}
+      icon={icon}
+    />
+  )
 }
 
 
@@ -31,5 +29,6 @@ Button.propTypes = {
 Button.defaultProps = {}
 
 Button.handledProps = ['className', 'icon', 'color']
+
 
 export default Button

--- a/src/lib/atoms/buttons/ExportButton.js
+++ b/src/lib/atoms/buttons/ExportButton.js
@@ -53,4 +53,5 @@ ExportButton.defaultProps = {
   filenamePrefix: 'export',
 }
 
+
 export default ExportButton

--- a/src/lib/atoms/buttons/UploadButton.js
+++ b/src/lib/atoms/buttons/UploadButton.js
@@ -6,7 +6,7 @@ import ReactFileReader from 'react-file-reader'
 import { Button } from 'LibIndex'
 
 
-class UploadButton extends React.PureComponent {
+class UploadButton extends React.Component {
   handleFiles = (files) => {
     const { config, handleResults } = this.props
     const reader = new FileReader()
@@ -92,5 +92,6 @@ UploadButton.defaultProps = {
     withCredentials: undefined,
   }
 }
+
 
 export default UploadButton

--- a/src/lib/atoms/dropdowns/autocomplete-dropdown.js
+++ b/src/lib/atoms/dropdowns/autocomplete-dropdown.js
@@ -4,7 +4,7 @@ import { Dropdown } from 'semantic-ui-react'
 import { omit } from 'lodash'
 
 
-class AutoCompleteDropDown extends React.PureComponent {
+class AutoCompleteDropDown extends React.Component {
   constructor(props) {
     super(props)
 
@@ -67,5 +67,6 @@ AutoCompleteDropDown.defaultProps = {
   waitInterval: 750,
   loading: false,
 }
+
 
 export default AutoCompleteDropDown

--- a/src/lib/atoms/fixed-data-table-cells/checkbox-fixed-cell.js
+++ b/src/lib/atoms/fixed-data-table-cells/checkbox-fixed-cell.js
@@ -5,7 +5,7 @@ import { Checkbox } from 'semantic-ui-react'
 import { get } from 'lodash'
 
 
-class CheckboxFixedCell extends React.PureComponent {
+class CheckboxFixedCell extends React.Component {
   constructor(props) {
     super(props)
 
@@ -44,5 +44,6 @@ CheckboxFixedCell.propTypes = {
 CheckboxFixedCell.defaultProps = {
   data: [],
 }
+
 
 export default CheckboxFixedCell

--- a/src/lib/atoms/fixed-data-table-cells/date-fixed-cell.js
+++ b/src/lib/atoms/fixed-data-table-cells/date-fixed-cell.js
@@ -6,17 +6,15 @@ import { get } from 'lodash'
 import { utils } from 'LibIndex'
 
 
-class DateFixedCell extends React.PureComponent {
-  render() {
-    const { data, rowIndex, columnKey, ...rest } = this.props
-    const date = get(data[rowIndex], columnKey)
+const DateFixedCell = props => {
+  const { data, rowIndex, columnKey, ...rest } = props
+  const date = get(data[rowIndex], columnKey)
 
-    return (
-      <Cell {...rest}>
-        {utils.dateFormatter(date)}
-      </Cell>
-    )
-  }
+  return (
+    <Cell {...rest}>
+      {utils.dateFormatter(date)}
+    </Cell>
+  )
 }
 
 
@@ -29,5 +27,6 @@ DateFixedCell.propTypes = {
 DateFixedCell.defaultProps = {
   data: [],
 }
+
 
 export default DateFixedCell

--- a/src/lib/atoms/fixed-data-table-cells/gene-fixed-cell.js
+++ b/src/lib/atoms/fixed-data-table-cells/gene-fixed-cell.js
@@ -7,29 +7,27 @@ import { get } from 'lodash'
 import { utils, Link } from 'LibIndex'
 
 
-class GeneFixedCell extends React.PureComponent {
-  render() {
-    const { data, rowIndex, columnKey, ...rest } = this.props
-    const gene = get(data[rowIndex], columnKey)
+const GeneFixedCell = props => {
+  const { data, rowIndex, columnKey, ...rest } = props
+  const gene = get(data[rowIndex], columnKey)
 
-    return (
-      <Cell {...rest}>
-        {gene} &nbsp;&nbsp;
-        <Link
-          content={<Label basic size="tiny" content="H" color="blue" />}
-          href={utils.urlBuilders.hgmdGene(gene)}
-        />
-        <Link
-          content={<Label basic size="tiny" content="O" color="green" />}
-          href={utils.urlBuilders.omimSearch(gene)}
-        />
-        <Link
-          content={<Label basic size="tiny" content="P" color="blue" />}
-          href={utils.urlBuilders.pubmedSearch(gene)}
-        />
-      </Cell>
-    )
-  }
+  return (
+    <Cell {...rest}>
+      {gene} &nbsp;&nbsp;
+      <Link
+        content={<Label basic size="tiny" content="H" color="blue" />}
+        href={utils.urlBuilders.hgmdGene(gene)}
+      />
+      <Link
+        content={<Label basic size="tiny" content="O" color="green" />}
+        href={utils.urlBuilders.omimSearch(gene)}
+      />
+      <Link
+        content={<Label basic size="tiny" content="P" color="blue" />}
+        href={utils.urlBuilders.pubmedSearch(gene)}
+      />
+    </Cell>
+  )
 }
 
 
@@ -42,5 +40,6 @@ GeneFixedCell.propTypes = {
 GeneFixedCell.defaultProps = {
   data: [],
 }
+
 
 export default GeneFixedCell

--- a/src/lib/atoms/fixed-data-table-cells/interpretation-fixed-cell.js
+++ b/src/lib/atoms/fixed-data-table-cells/interpretation-fixed-cell.js
@@ -7,18 +7,16 @@ import { get } from 'lodash'
 import { utils } from 'LibIndex'
 
 
-class InterpretationFixedCell extends React.PureComponent {
-  render() {
-    const { labelProps, data, rowIndex, columnKey, ...rest } = this.props
-    const classification = get(data[rowIndex], columnKey)
-    const color = utils.getInterpretationColor(classification)
+const InterpretationFixedCell = props => {
+  const { labelProps, data, rowIndex, columnKey, ...rest } = props
+  const classification = get(data[rowIndex], columnKey)
+  const color = utils.getInterpretationColor(classification)
 
-    return (
-      <Cell {...rest}>
-        <Label {...labelProps} color={color} content={classification} />
-      </Cell>
-    )
-  }
+  return (
+    <Cell {...rest}>
+      <Label {...labelProps} color={color} content={classification} />
+    </Cell>
+  )
 }
 
 
@@ -35,5 +33,6 @@ InterpretationFixedCell.defaultProps = {
     basic: true,
   },
 }
+
 
 export default InterpretationFixedCell

--- a/src/lib/atoms/fixed-data-table-cells/link-fixed-cell.js
+++ b/src/lib/atoms/fixed-data-table-cells/link-fixed-cell.js
@@ -7,29 +7,27 @@ import { Link } from 'LibIndex'
 import * as customPropTypes from 'LibSrc/helpers/customPropTypes'
 
 
-class LinkFixedCell extends React.PureComponent {
-  render() {
-    const { as, urlBuilder, data, rowIndex, columnKey, idKey, ...rest } = this.props
-    const content = get(data[rowIndex], columnKey)
-    const id = get(data[rowIndex], idKey, undefined)
+const LinkFixedCell = props => {
+  const { as, urlBuilder, data, rowIndex, columnKey, idKey, ...rest } = props
+  const content = get(data[rowIndex], columnKey)
+  const id = get(data[rowIndex], idKey, undefined)
 
-    // Build url depending if id is passed or search term
-    let url = urlBuilder(content)
-    if (id !== undefined) {
-        url = urlBuilder(id)
-    }
-
-    let link = <Link as={as} content={content} href={url} />
-    if (as !== 'a') {
-      link = <Link as={as} content={content} to={url} />
-    }
-
-    return (
-      <Cell {...rest}>
-        {link}
-      </Cell>
-    )
+  // Build url depending if id is passed or search term
+  let url = urlBuilder(content)
+  if (id !== undefined) {
+      url = urlBuilder(id)
   }
+
+  let link = <Link as={as} content={content} href={url} />
+  if (as !== 'a') {
+    link = <Link as={as} content={content} to={url} />
+  }
+
+  return (
+    <Cell {...rest}>
+      {link}
+    </Cell>
+  )
 }
 
 
@@ -46,5 +44,6 @@ LinkFixedCell.defaultProps = {
   data: [],
   as: 'a',
 }
+
 
 export default LinkFixedCell

--- a/src/lib/atoms/fixed-data-table-cells/molecular-consequence-fixed-cell.js
+++ b/src/lib/atoms/fixed-data-table-cells/molecular-consequence-fixed-cell.js
@@ -7,18 +7,16 @@ import { get } from 'lodash'
 import { utils } from 'LibIndex'
 
 
-class MolecularConsequenceFixedCell extends React.PureComponent {
-  render() {
-    const { labelProps, data, rowIndex, columnKey, ...rest } = this.props
-    const consequence = get(data[rowIndex], columnKey)
-    const color = utils.getMolecularConsequenceColor(consequence)
+const MolecularConsequenceFixedCell = props => {
+  const { labelProps, data, rowIndex, columnKey, ...rest } = props
+  const consequence = get(data[rowIndex], columnKey)
+  const color = utils.getMolecularConsequenceColor(consequence)
 
-    return (
-      <Cell {...rest}>
-        <Label {...labelProps} color={color} content={consequence} />
-      </Cell>
-    )
-  }
+  return (
+    <Cell {...rest}>
+      <Label {...labelProps} color={color} content={consequence} />
+    </Cell>
+  )
 }
 
 
@@ -35,5 +33,6 @@ MolecularConsequenceFixedCell.defaultProps = {
     basic: true,
   },
 }
+
 
 export default MolecularConsequenceFixedCell

--- a/src/lib/atoms/fixed-data-table-cells/sex-fixed-cell.js
+++ b/src/lib/atoms/fixed-data-table-cells/sex-fixed-cell.js
@@ -6,25 +6,23 @@ import { get, toLower, toString } from 'lodash'
 import { MaleIcon, FemaleIcon, QuestionIcon } from 'LibIndex'
 
 
-class SexFixedCell extends React.PureComponent {
-  render() {
-    const { data, rowIndex, columnKey, ...rest } = this.props
-    const sex = get(data[rowIndex], columnKey)
-    const normalizedSex = toLower(toString(sex))
+const SexFixedCell = props => {
+  const { data, rowIndex, columnKey, ...rest } = props
+  const sex = get(data[rowIndex], columnKey)
+  const normalizedSex = toLower(toString(sex))
 
-    let icon = <QuestionIcon />
-    if (['m', 'male', '1'].includes(normalizedSex)) {
-      icon = <MaleIcon />
-    } else if (['f', 'female', '2'].includes(normalizedSex)) {
-      icon = <FemaleIcon />
-    }
-
-    return (
-      <Cell {...rest}>
-        {icon}
-      </Cell>
-    )
+  let icon = <QuestionIcon />
+  if (['m', 'male', '1'].includes(normalizedSex)) {
+    icon = <MaleIcon />
+  } else if (['f', 'female', '2'].includes(normalizedSex)) {
+    icon = <FemaleIcon />
   }
+
+  return (
+    <Cell {...rest}>
+      {icon}
+    </Cell>
+  )
 }
 
 
@@ -37,5 +35,6 @@ SexFixedCell.propTypes = {
 SexFixedCell.defaultProps = {
   data: [],
 }
+
 
 export default SexFixedCell

--- a/src/lib/atoms/fixed-data-table-cells/status-fixed-cell.js
+++ b/src/lib/atoms/fixed-data-table-cells/status-fixed-cell.js
@@ -5,39 +5,37 @@ import { Icon } from 'semantic-ui-react'
 import { get } from 'lodash'
 
 
-class StatusFixedCell extends React.PureComponent {
-  render() {
-    const { data, rowIndex, columnKey, ...rest } = this.props
-    const status = get(data[rowIndex], columnKey)
+const StatusFixedCell = props => {
+  const { data, rowIndex, columnKey, ...rest } = props
+  const status = get(data[rowIndex], columnKey)
 
-    let icon
-    switch (status) {
-      case 'pending':
-        icon = <Icon color="grey" name="clock" />
-        break
-      case 'running':
-        icon = <Icon className="genomix" color="black" name="spinner" />
-        break
-      case 'complete':
-        icon = <Icon color="green" name="checkmark" />
-        break
-      case 'cancelled':
-        icon = <Icon color="red" name="dont" />
-        break
-      case 'failed':
-        icon = <Icon color="red" name="x" />
-        break
-      default:
-        icon = <Icon color="grey" name="question" />
-        break
-    }
-
-    return (
-      <Cell {...rest}>
-        {icon}
-      </Cell>
-    )
+  let icon
+  switch (status) {
+    case 'pending':
+      icon = <Icon color="grey" name="clock" />
+      break
+    case 'running':
+      icon = <Icon className="genomix" color="black" name="spinner" />
+      break
+    case 'complete':
+      icon = <Icon color="green" name="checkmark" />
+      break
+    case 'cancelled':
+      icon = <Icon color="red" name="dont" />
+      break
+    case 'failed':
+      icon = <Icon color="red" name="x" />
+      break
+    default:
+      icon = <Icon color="grey" name="question" />
+      break
   }
+
+  return (
+    <Cell {...rest}>
+      {icon}
+    </Cell>
+  )
 }
 
 
@@ -50,5 +48,6 @@ StatusFixedCell.propTypes = {
 StatusFixedCell.defaultProps = {
   data: [],
 }
+
 
 export default StatusFixedCell

--- a/src/lib/atoms/fixed-data-table-cells/text-fixed-cell.js
+++ b/src/lib/atoms/fixed-data-table-cells/text-fixed-cell.js
@@ -4,17 +4,15 @@ import { Cell } from 'fixed-data-table-2'
 import { get } from 'lodash'
 
 
-class TextFixedCell extends React.PureComponent {
-  render() {
-    const { data, rowIndex, columnKey, ...rest } = this.props
-    const text = get(data[rowIndex], columnKey)
+const TextFixedCell = props => {
+  const { data, rowIndex, columnKey, ...rest } = props
+  const text = get(data[rowIndex], columnKey)
 
-    return (
-      <Cell {...rest}>
-        {text}
-      </Cell>
-    )
-  }
+  return (
+    <Cell {...rest}>
+      {text}
+    </Cell>
+  )
 }
 
 
@@ -27,5 +25,6 @@ TextFixedCell.propTypes = {
 TextFixedCell.defaultProps = {
   data: [],
 }
+
 
 export default TextFixedCell

--- a/src/lib/atoms/fixed-data-table-cells/transcript-fixed-cell.js
+++ b/src/lib/atoms/fixed-data-table-cells/transcript-fixed-cell.js
@@ -7,21 +7,19 @@ import { get } from 'lodash'
 import { utils, Link } from 'LibIndex'
 
 
-class TranscriptFixedCell extends React.PureComponent {
-  render() {
-    const { data, rowIndex, columnKey, ...rest } = this.props
-    const transcript = get(data[rowIndex], columnKey)
+const TranscriptFixedCell = props => {
+  const { data, rowIndex, columnKey, ...rest } = props
+  const transcript = get(data[rowIndex], columnKey)
 
-    return (
-      <Cell {...rest}>
-        {transcript} &nbsp;&nbsp;
-        <Link
-          content={<Label basic size="tiny" content="A" color="brown" />}
-          href={utils.urlBuilders.alamutEntry(transcript)}
-        />
-      </Cell>
-    )
-  }
+  return (
+    <Cell {...rest}>
+      {transcript} &nbsp;&nbsp;
+      <Link
+        content={<Label basic size="tiny" content="A" color="brown" />}
+        href={utils.urlBuilders.alamutEntry(transcript)}
+      />
+    </Cell>
+  )
 }
 
 
@@ -34,5 +32,6 @@ TranscriptFixedCell.propTypes = {
 TranscriptFixedCell.defaultProps = {
   data: [],
 }
+
 
 export default TranscriptFixedCell

--- a/src/lib/atoms/fixed-data-table-cells/turn-around-time-fixed-cell.js
+++ b/src/lib/atoms/fixed-data-table-cells/turn-around-time-fixed-cell.js
@@ -6,29 +6,28 @@ import { get } from 'lodash'
 import { TurnAroundTimeProgress } from 'LibIndex'
 
 
-class TurnAroundTimeProgressFixedCell extends React.PureComponent {
-  render() {
-    const {
-      data, rowIndex, columnKey,
-      progressProps, targetKey, startKey, signoutKey,
-      ...rest
-    } = this.props
-    const rowData = data[rowIndex]
-    const target = get(rowData, targetKey)
-    const start = get(rowData, startKey)
-    const signout = get(rowData, signoutKey)
+const TurnAroundTimeProgressFixedCell = props => {
+  const {
+    data, rowIndex, columnKey,
+    progressProps, targetKey, startKey, signoutKey,
+    ...rest
+  } = props
 
-    return (
-      <Cell {...rest}>
-        <TurnAroundTimeProgress
-          target={target}
-          start={start}
-          signout={signout}
-          {...progressProps}
-        />
-      </Cell>
-    )
-  }
+  const rowData = data[rowIndex]
+  const target = get(rowData, targetKey)
+  const start = get(rowData, startKey)
+  const signout = get(rowData, signoutKey)
+
+  return (
+    <Cell {...rest}>
+      <TurnAroundTimeProgress
+        target={target}
+        start={start}
+        signout={signout}
+        {...progressProps}
+      />
+    </Cell>
+  )
 }
 
 
@@ -48,5 +47,6 @@ TurnAroundTimeProgressFixedCell.defaultProps = {
     size: 'tiny',
   },
 }
+
 
 export default TurnAroundTimeProgressFixedCell

--- a/src/lib/atoms/icons/Icon.js
+++ b/src/lib/atoms/icons/Icon.js
@@ -6,18 +6,16 @@ import cx from 'classnames'
 import getUnhandledProps from 'LibSrc/helpers/getUnhandledProps'
 
 
-class Icon extends React.PureComponent {
-  render() {
-    const iconProps = getUnhandledProps(Icon, this.props)
-    const { color, icon } = this.props
+const Icon = props => {
+  const iconProps = getUnhandledProps(Icon, props)
+  const { className, color, icon } = props
 
-    return (
-      <SemanticIcon
-        {...iconProps}
-        className={cx(this.props.className, 'genomix', color, icon)}
-      />
-    )
-  }
+  return (
+    <SemanticIcon
+      { ...iconProps }
+      className={cx(className, 'genomix', color, icon)}
+    />
+  )
 }
 
 
@@ -30,5 +28,6 @@ Icon.propTypes = {
 Icon.defaultProps = {}
 
 Icon.handledProps = ['className', 'icon', 'color']
+
 
 export default Icon

--- a/src/lib/atoms/links/link.js
+++ b/src/lib/atoms/links/link.js
@@ -6,24 +6,22 @@ import getElementType from 'LibSrc/helpers/getElementType'
 import getUnhandledProps from 'LibSrc/helpers/getUnhandledProps'
 
 
-class Link extends React.PureComponent {
-  render() {
-    const ElementType = getElementType(Link, this.props)
-    const rest = getUnhandledProps(Link, this.props)
-    const { content } = this.props
+const Link = props => {
+  const ElementType = getElementType(Link, props)
+  const rest = getUnhandledProps(Link, props)
+  const { content } = props
 
-    const additionalProps = {}
-    if (ElementType === 'a') {
-      additionalProps.target = '_blank'
-      additionalProps.rel = 'noopener noreferrer'
-    }
-
-    return (
-      <ElementType {...rest} {...additionalProps}>
-        {content}
-      </ElementType>
-    )
+  const additionalProps = {}
+  if (ElementType === 'a') {
+    additionalProps.target = '_blank'
+    additionalProps.rel = 'noopener noreferrer'
   }
+
+  return (
+    <ElementType {...rest} {...additionalProps}>
+      {content}
+    </ElementType>
+  )
 }
 
 
@@ -37,5 +35,6 @@ Link.defaultProps = {
 }
 
 Link.handledProps = ['as', 'content']
+
 
 export default Link

--- a/src/lib/atoms/links/link.test.js
+++ b/src/lib/atoms/links/link.test.js
@@ -11,12 +11,6 @@ describe('Test Link', () => {
     ReactDOM.render(<Link as="a" content="google" href="https://www.google.com" />, div)
   })
 
-  it('initial props are set correctly', () => {
-    const wrapper = shallow(<Link />)
-    expect(wrapper.instance().props.as).toEqual('a')
-    expect(wrapper.instance().props.content).toEqual(undefined)
-  })
-
   it('props are spread correctly', () => {
     const href = 'https://www.google.com'
     const content = 'google'

--- a/src/lib/atoms/media/avatar.js
+++ b/src/lib/atoms/media/avatar.js
@@ -4,22 +4,20 @@ import { Image, Icon } from 'semantic-ui-react'
 import faker from 'faker'
 
 
-class Avatar extends React.PureComponent {
-  render() {
-    const { profileImage } = this.props
+const Avatar = props => {
+  const { profileImage } = props
 
-    let src = profileImage
-    if (!src) {
-      src = faker.internet.avatar()
-    }
-
-    return (
-      <div>
-        <Image avatar src={src} />
-        <Icon name="chevron down" size="small"/>
-      </div>
-    )
+  let src = profileImage
+  if (!src) {
+    src = faker.internet.avatar()
   }
+
+  return (
+    <div>
+      <Image avatar src={src} />
+      <Icon name="chevron down" size="small"/>
+    </div>
+  )
 }
 
 
@@ -30,5 +28,6 @@ Avatar.propTypes = {
 Avatar.defaultProps = {
   profileImage: undefined,
 }
+
 
 export default Avatar

--- a/src/lib/atoms/media/logo.js
+++ b/src/lib/atoms/media/logo.js
@@ -5,19 +5,7 @@ import { Image } from 'semantic-ui-react'
 import logo from 'LibSrc/assets/chopLogo.ico'
 
 
-class Logo extends React.PureComponent {
-  render() {
-    const { width, src, ...rest } = this.props
-
-    return (
-      <Image
-        width={width}
-        src={src}
-        {...rest}
-      />
-    )
-  }
-}
+const Logo = props => <Image {...props} />
 
 
 Logo.propTypes = {
@@ -29,5 +17,6 @@ Logo.defaultProps = {
   width: '120px',
   src: logo,
 }
+
 
 export default Logo

--- a/src/lib/atoms/progress-bars/turn-around-time-progress.js
+++ b/src/lib/atoms/progress-bars/turn-around-time-progress.js
@@ -5,19 +5,11 @@ import { Popup, Progress } from 'semantic-ui-react'
 import { utils } from 'LibIndex'
 
 
-class TurnAroundTimeProgress extends React.PureComponent {
-  renderNA = () => {
-    return (
-      <p>
-        Not started!
-      </p>
-    )
-  }
+const TurnAroundTimeProgress = props => {
+  const { target, start, signout, ...rest } = props
+  const { label, color, value } = utils.getTurnAroundTimeDetails(target, start, signout)
 
-  renderProgress = () => {
-    const { target, start, signout, ...rest } = this.props
-    const { label, color, value } = utils.getTurnAroundTimeDetails(target, start, signout)
-
+  if (start) {
     return (
       <Popup
         flowing
@@ -39,16 +31,12 @@ class TurnAroundTimeProgress extends React.PureComponent {
         </Popup.Content>
       </Popup>
     )
-  }
-
-  render() {
-    const { start } = this.props
-
-    if (start) {
-      return this.renderProgress()
-    } else {
-      return this.renderNA()
-    }
+  } else {
+    return (
+      <p>
+        Not started!
+      </p>
+    )
   }
 }
 
@@ -60,5 +48,6 @@ TurnAroundTimeProgress.propTypes = {
 }
 
 TurnAroundTimeProgress.defaultProps = {}
+
 
 export default TurnAroundTimeProgress

--- a/src/lib/atoms/table-cells/checkbox-cell.js
+++ b/src/lib/atoms/table-cells/checkbox-cell.js
@@ -7,7 +7,7 @@ import getElementType from 'LibSrc/helpers/getElementType'
 import getUnhandledProps from 'LibSrc/helpers/getUnhandledProps'
 
 
-class CheckboxCell extends React.PureComponent {
+class CheckboxCell extends React.Component {
   onChange = (e) => {
     const { onChange, rowIndex } = this.props
     onChange(rowIndex)
@@ -41,5 +41,6 @@ CheckboxCell.handledProps = [
   'onChange',
   'rowIndex',
 ]
+
 
 export default CheckboxCell

--- a/src/lib/atoms/table-cells/date-cell.js
+++ b/src/lib/atoms/table-cells/date-cell.js
@@ -7,19 +7,17 @@ import getElementType from 'LibSrc/helpers/getElementType'
 import getUnhandledProps from 'LibSrc/helpers/getUnhandledProps'
 
 
-class DateCell extends React.PureComponent {
-  render() {
-    const ElementType = getElementType(DateCell, this.props)
-    const rest = getUnhandledProps(DateCell, this.props)
-    const { date, format } = this.props
-    const normalizedDate = utils.dateFormatter(date, format)
+const DateCell = props => {
+  const ElementType = getElementType(DateCell, props)
+  const rest = getUnhandledProps(DateCell, props)
+  const { date, format } = props
+  const normalizedDate = utils.dateFormatter(date, format)
 
-    return (
-      <ElementType {...rest}>
-        {normalizedDate}
-      </ElementType>
-    )
-  }
+  return (
+    <ElementType {...rest}>
+      {normalizedDate}
+    </ElementType>
+  )
 }
 
 
@@ -40,5 +38,6 @@ DateCell.handledProps = [
   'format',
   'rowIndex',
 ]
+
 
 export default DateCell

--- a/src/lib/atoms/table-cells/date-cell.test.js
+++ b/src/lib/atoms/table-cells/date-cell.test.js
@@ -11,14 +11,6 @@ describe('Test DateCell', () => {
     ReactDOM.render(<DateCell rowIndex={1} date="1987-12-18" />, div)
   })
 
-  it('initial props are set correctly', () => {
-    const wrapper = shallow(<DateCell rowIndex={1} date="1987-12-18" />)
-    expect(wrapper.instance().props.rowIndex).toEqual(1)
-    expect(wrapper.instance().props.as).toEqual('div')
-    expect(wrapper.instance().props.date).toEqual('1987-12-18')
-    expect(wrapper.instance().props.format).toEqual(undefined)
-  })
-
   it('initial props are set correctly as td', () => {
     const wrapper = shallow(<DateCell rowIndex={1} date="1987-12-18" />)
     expect(wrapper.props().children).toEqual('12/18/1987')

--- a/src/lib/atoms/table-cells/dropdown-cell.js
+++ b/src/lib/atoms/table-cells/dropdown-cell.js
@@ -7,7 +7,7 @@ import getElementType from 'LibSrc/helpers/getElementType'
 import getUnhandledProps from 'LibSrc/helpers/getUnhandledProps'
 
 
-class DropdownCell extends React.PureComponent {
+class DropdownCell extends React.Component {
   constructor(props) {
     super(props)
 
@@ -90,5 +90,6 @@ DropdownCell.handledProps = [
   'dropDownProps',
   'options',
 ]
+
 
 export default DropdownCell

--- a/src/lib/atoms/table-cells/gene-cell.js
+++ b/src/lib/atoms/table-cells/gene-cell.js
@@ -8,31 +8,28 @@ import getElementType from 'LibSrc/helpers/getElementType'
 import getUnhandledProps from 'LibSrc/helpers/getUnhandledProps'
 
 
-class GeneCell extends React.PureComponent {
-  render() {
-    const ElementType = getElementType(GeneCell, this.props)
-    const rest = getUnhandledProps(GeneCell, this.props)
-    const { gene } = this.props
+const GeneCell = props => {
+  const ElementType = getElementType(GeneCell, props)
+  const rest = getUnhandledProps(GeneCell, props)
+  const { gene } = props
 
-
-    return (
-      <ElementType {...rest}>
-        {gene} &nbsp;&nbsp;
-        <Link
-          content={<Label basic size="tiny" content="H" color="blue" />}
-          href={utils.urlBuilders.hgmdGene(gene)}
-        />
-        <Link
-          content={<Label basic size="tiny" content="O" color="green" />}
-          href={utils.urlBuilders.omimSearch(gene)}
-        />
-        <Link
-          content={<Label basic size="tiny" content="P" color="blue" />}
-          href={utils.urlBuilders.pubmedSearch(gene)}
-        />
-      </ElementType>
-    )
-  }
+  return (
+    <ElementType {...rest}>
+      {gene} &nbsp;&nbsp;
+      <Link
+        content={<Label basic size="tiny" content="H" color="blue" />}
+        href={utils.urlBuilders.hgmdGene(gene)}
+      />
+      <Link
+        content={<Label basic size="tiny" content="O" color="green" />}
+        href={utils.urlBuilders.omimSearch(gene)}
+      />
+      <Link
+        content={<Label basic size="tiny" content="P" color="blue" />}
+        href={utils.urlBuilders.pubmedSearch(gene)}
+      />
+    </ElementType>
+  )
 }
 
 
@@ -51,5 +48,6 @@ GeneCell.handledProps = [
   'gene',
   'rowIndex',
 ]
+
 
 export default GeneCell

--- a/src/lib/atoms/table-cells/gene-cell.test.js
+++ b/src/lib/atoms/table-cells/gene-cell.test.js
@@ -11,13 +11,6 @@ describe('Test GeneCell', () => {
     ReactDOM.render(<GeneCell gene="PNPLA6" />, div)
   })
 
-  it('initial props are set correctly', () => {
-    const wrapper = shallow(<GeneCell gene="PNPLA6" />)
-    expect(wrapper.instance().props.as).toEqual('div')
-    expect(wrapper.instance().props.gene).toEqual('PNPLA6')
-    expect(wrapper.instance().props.rowIndex).toEqual(undefined)
-  })
-
   it('children are rendered correctly (5 children and 3 Links)', () => {
     const wrapper = shallow(<GeneCell gene="PNPLA6" />)
     expect(wrapper.props().children.length).toEqual(5)  // NOTE: space is counted as a child

--- a/src/lib/atoms/table-cells/interpretation-cell.js
+++ b/src/lib/atoms/table-cells/interpretation-cell.js
@@ -8,20 +8,18 @@ import getElementType from 'LibSrc/helpers/getElementType'
 import getUnhandledProps from 'LibSrc/helpers/getUnhandledProps'
 
 
-class InterpretationCell extends React.PureComponent {
-  render() {
-    const ElementType = getElementType(InterpretationCell, this.props)
-    const rest = getUnhandledProps(InterpretationCell, this.props)
-    const { classification, labelProps } = this.props
-    const color = utils.getInterpretationColor(classification)
+const InterpretationCell = props => {
+  const ElementType = getElementType(InterpretationCell, props)
+  const rest = getUnhandledProps(InterpretationCell, props)
+  const { classification, labelProps } = props
+  const color = utils.getInterpretationColor(classification)
 
 
-    return (
-      <ElementType {...rest}>
-        <Label {...labelProps} color={color} content={classification} />
-      </ElementType>
-    )
-  }
+  return (
+    <ElementType {...rest}>
+      <Label {...labelProps} color={color} content={classification} />
+    </ElementType>
+  )
 }
 
 
@@ -52,5 +50,6 @@ InterpretationCell.handledProps = [
   'rowIndex',
   'labelProps',
 ]
+
 
 export default InterpretationCell

--- a/src/lib/atoms/table-cells/interpretation-cell.test.js
+++ b/src/lib/atoms/table-cells/interpretation-cell.test.js
@@ -11,14 +11,6 @@ describe('Test InterpretationCell', () => {
     ReactDOM.render(<InterpretationCell classification="benign" />, div)
   })
 
-  it('initial props are set correctly', () => {
-    const wrapper = shallow(<InterpretationCell classification="benign" />)
-    expect(wrapper.instance().props.as).toEqual('div')
-    expect(wrapper.instance().props.classification).toEqual('benign')
-    expect(wrapper.instance().props.rowIndex).toEqual(undefined)
-    expect(wrapper.instance().props.labelProps).toEqual({ basic: true })
-  })
-
   it('ensure labelProps are spread to label', () => {
     const wrapper = shallow(<InterpretationCell classification="benign" labelProps={{ size: 'large', basic: true }} />)
     expect(wrapper.find('Label').props()).toEqual({"basic": true, "color": "green", "content": "benign", "size": "large"})

--- a/src/lib/atoms/table-cells/link-cell.js
+++ b/src/lib/atoms/table-cells/link-cell.js
@@ -7,19 +7,17 @@ import getElementType from 'LibSrc/helpers/getElementType'
 import getUnhandledProps from 'LibSrc/helpers/getUnhandledProps'
 
 
-class LinkCell extends React.PureComponent {
-  render() {
-    const { as, linkAs, content } = this.props
+const LinkCell = props => {
+  const { as, linkAs, content } = props
 
-    const ElementType = getElementType(LinkCell, { as })
-    const rest = getUnhandledProps(LinkCell, this.props)
+  const ElementType = getElementType(LinkCell, { as })
+  const rest = getUnhandledProps(LinkCell, props)
 
-    return (
-      <ElementType {...rest}>
-        <Link {...rest} as={linkAs} content={content} />
-      </ElementType>
-    )
-  }
+  return (
+    <ElementType {...rest}>
+      <Link {...rest} as={linkAs} content={content} />
+    </ElementType>
+  )
 }
 
 
@@ -45,5 +43,6 @@ LinkCell.handledProps = [
   'content',
   'linkAs',
 ]
+
 
 export default LinkCell

--- a/src/lib/atoms/table-cells/link-cell.test.js
+++ b/src/lib/atoms/table-cells/link-cell.test.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
-import { mount, shallow } from 'enzyme'
+import { shallow } from 'enzyme'
 
 import { LinkCell } from 'LibIndex'
 
@@ -18,21 +18,6 @@ describe('Test LinkCell', () => {
     ReactDOM.render(component, div)
   })
 
-  it('initial props are set correctly', () => {
-    const component = (
-      <LinkCell
-        href="http://www.google.com"
-        content="hi"
-      />
-    )
-    const wrapper = shallow(component)
-    expect(wrapper.instance().props.as).toEqual('div')
-    expect(wrapper.instance().props.rowIndex).toEqual(undefined)
-    expect(wrapper.instance().props.content).toEqual('hi')
-    expect(wrapper.instance().props.linkAs).toEqual('a')
-    expect(wrapper.instance().props.href).toEqual('http://www.google.com')
-  })
-
   it('props are spread correctly', () => {
     const component = (
       <LinkCell
@@ -42,7 +27,7 @@ describe('Test LinkCell', () => {
         rowIndex={1}
       />
     )
-    const wrapper = mount(component)
+    const wrapper = shallow(component)
     expect(wrapper.find('Link').props().as).toEqual('p')
     expect(wrapper.find('Link').props().href).toEqual('app/1')
     expect(wrapper.find('Link').props().content).toEqual('hi')

--- a/src/lib/atoms/table-cells/molecular-consequence-cell.js
+++ b/src/lib/atoms/table-cells/molecular-consequence-cell.js
@@ -8,19 +8,17 @@ import getElementType from 'LibSrc/helpers/getElementType'
 import getUnhandledProps from 'LibSrc/helpers/getUnhandledProps'
 
 
-class MolecularConsequenceCell extends React.PureComponent {
-  render() {
-    const ElementType = getElementType(MolecularConsequenceCell, this.props)
-    const rest = getUnhandledProps(MolecularConsequenceCell, this.props)
-    const { consequence, labelProps } = this.props
-    const color = utils.getMolecularConsequenceColor(consequence)
+const MolecularConsequenceCell = props => {
+  const ElementType = getElementType(MolecularConsequenceCell, props)
+  const rest = getUnhandledProps(MolecularConsequenceCell, props)
+  const { consequence, labelProps } = props
+  const color = utils.getMolecularConsequenceColor(consequence)
 
-    return (
-      <ElementType {...rest}>
-        <Label {...labelProps} color={color} content={consequence} />
-      </ElementType>
-    )
-  }
+  return (
+    <ElementType {...rest}>
+      <Label {...labelProps} color={color} content={consequence} />
+    </ElementType>
+  )
 }
 
 
@@ -44,5 +42,6 @@ MolecularConsequenceCell.handledProps = [
   'rowIndex',
   'labelProps',
 ]
+
 
 export default MolecularConsequenceCell

--- a/src/lib/atoms/table-cells/molecular-consequence-cell.test.js
+++ b/src/lib/atoms/table-cells/molecular-consequence-cell.test.js
@@ -11,14 +11,6 @@ describe('Test MolecularConsequenceCell', () => {
     ReactDOM.render(<MolecularConsequenceCell consequence="missense" />, div)
   })
 
-  it('initial props are set correctly', () => {
-    const wrapper = shallow(<MolecularConsequenceCell consequence="missense" />)
-    expect(wrapper.instance().props.as).toEqual('div')
-    expect(wrapper.instance().props.consequence).toEqual('missense')
-    expect(wrapper.instance().props.rowIndex).toEqual(undefined)
-    expect(wrapper.instance().props.labelProps).toEqual({ basic: true })
-  })
-
   it('ensure labelProps are spread to label', () => {
     const wrapper = shallow(<MolecularConsequenceCell consequence="missense" labelProps={{ size: 'large', basic: true }} />)
     expect(wrapper.find('Label').props()).toEqual({"basic": true, "color": "orange", "content": "missense", "size": "large"})

--- a/src/lib/atoms/table-cells/public-resources-evidence-cell.js
+++ b/src/lib/atoms/table-cells/public-resources-evidence-cell.js
@@ -8,7 +8,7 @@ import getElementType from 'LibSrc/helpers/getElementType'
 import getUnhandledProps from 'LibSrc/helpers/getUnhandledProps'
 
 
-class PublicEvidenceCell extends React.PureComponent {
+class PublicEvidenceCell extends React.Component {
   renderRating = (database, value, url) => {
     let color = 'grey'
     let message = `Not present in ${database}!`
@@ -103,5 +103,6 @@ PublicEvidenceCell.handledProps = [
   'gnomadFrequency',
   'rowIndex',
 ]
+
 
 export default PublicEvidenceCell

--- a/src/lib/atoms/table-cells/sex-cell.js
+++ b/src/lib/atoms/table-cells/sex-cell.js
@@ -8,29 +8,27 @@ import getElementType from 'LibSrc/helpers/getElementType'
 import getUnhandledProps from 'LibSrc/helpers/getUnhandledProps'
 
 
-class SexCell extends React.PureComponent {
-  render() {
-    const ElementType = getElementType(SexCell, this.props)
-    const rest = getUnhandledProps(SexCell, this.props)
-    const { sex, iconProps } = this.props
+const SexCell = props => {
+  const ElementType = getElementType(SexCell, props)
+  const rest = getUnhandledProps(SexCell, props)
+  const { sex, iconProps } = props
 
-    // PED file nomenclature for sex. Anything else is unknown
-    // See: https://gatkforums.broadinstitute.org/gatk/discussion/7696/pedigree-ped-files
-    const normalizedSex = toLower(toString(sex))
+  // PED file nomenclature for sex. Anything else is unknown
+  // See: https://gatkforums.broadinstitute.org/gatk/discussion/7696/pedigree-ped-files
+  const normalizedSex = toLower(toString(sex))
 
-    let icon = <QuestionIcon {...iconProps} />
-    if (['m', 'male', '1'].includes(normalizedSex)) {
-      icon = <MaleIcon {...iconProps} />
-    } else if (['f', 'female', '2'].includes(normalizedSex)) {
-      icon = <FemaleIcon {...iconProps} />
-    }
-
-    return (
-      <ElementType {...rest}>
-        {icon}
-      </ElementType>
-    )
+  let icon = <QuestionIcon {...iconProps} />
+  if (['m', 'male', '1'].includes(normalizedSex)) {
+    icon = <MaleIcon {...iconProps} />
+  } else if (['f', 'female', '2'].includes(normalizedSex)) {
+    icon = <FemaleIcon {...iconProps} />
   }
+
+  return (
+    <ElementType {...rest}>
+      {icon}
+    </ElementType>
+  )
 }
 
 
@@ -56,5 +54,6 @@ SexCell.handledProps = [
   'rowIndex',
   'iconProps',
 ]
+
 
 export default SexCell

--- a/src/lib/atoms/table-cells/sex-cell.test.js
+++ b/src/lib/atoms/table-cells/sex-cell.test.js
@@ -11,14 +11,6 @@ describe('Test SexCell', () => {
     ReactDOM.render(<SexCell />, div)
   })
 
-  it('initial props are set correctly', () => {
-    const wrapper = shallow(<SexCell />)
-    expect(wrapper.instance().props.as).toEqual('div')
-    expect(wrapper.instance().props.sex).toEqual('unknown')
-    expect(wrapper.instance().props.rowIndex).toEqual(undefined)
-    expect(wrapper.instance().props.iconProps).toEqual({})
-  })
-
   it('ensure iconProps are spread to icon', () => {
     const wrapper = shallow(<SexCell as="td" iconProps={{ size: 'large' }} />)
     expect(wrapper.find('QuestionIcon').props()).toEqual({ size: 'large' })

--- a/src/lib/atoms/table-cells/status-cell.js
+++ b/src/lib/atoms/table-cells/status-cell.js
@@ -7,40 +7,38 @@ import getElementType from 'LibSrc/helpers/getElementType'
 import getUnhandledProps from 'LibSrc/helpers/getUnhandledProps'
 
 
-class StatusCell extends React.PureComponent {
-  render() {
-    const ElementType = getElementType(StatusCell, this.props)
-    const rest = getUnhandledProps(StatusCell, this.props)
-    const { status } = this.props
+const StatusCell = props => {
+  const ElementType = getElementType(StatusCell, props)
+  const rest = getUnhandledProps(StatusCell, props)
+  const { status } = props
 
-    let icon
-    switch (status) {
-      case 'pending':
-        icon = <Icon color="grey" name="clock" />
-        break
-      case 'running':
-        icon = <Icon className="genomix" color="black" name="spinner" />
-        break
-      case 'complete':
-        icon = <Icon color="green" name="checkmark" />
-        break
-      case 'cancelled':
-        icon = <Icon color="red" name="dont" />
-        break
-      case 'failed':
-        icon = <Icon color="red" name="x" />
-        break
-      default:
-        icon = <Icon color="grey" name="question" />
-        break
-    }
-
-    return (
-      <ElementType {...rest}>
-        {icon}
-      </ElementType>
-    )
+  let icon
+  switch (status) {
+    case 'pending':
+      icon = <Icon color="grey" name="clock" />
+      break
+    case 'running':
+      icon = <Icon className="genomix" color="black" name="spinner" />
+      break
+    case 'complete':
+      icon = <Icon color="green" name="checkmark" />
+      break
+    case 'cancelled':
+      icon = <Icon color="red" name="dont" />
+      break
+    case 'failed':
+      icon = <Icon color="red" name="x" />
+      break
+    default:
+      icon = <Icon color="grey" name="question" />
+      break
   }
+
+  return (
+    <ElementType {...rest}>
+      {icon}
+    </ElementType>
+  )
 }
 
 
@@ -66,5 +64,6 @@ StatusCell.handledProps = [
   'status',
   'rowIndex',
 ]
+
 
 export default StatusCell

--- a/src/lib/atoms/table-cells/status-cell.test.js
+++ b/src/lib/atoms/table-cells/status-cell.test.js
@@ -11,13 +11,6 @@ describe('Test StatusCell', () => {
     ReactDOM.render(<StatusCell status="unknown" />, div)
   })
 
-  it('initial props are set correctly', () => {
-    const wrapper = shallow(<StatusCell status="unknown" />)
-    expect(wrapper.instance().props.as).toEqual('div')
-    expect(wrapper.instance().props.status).toEqual('unknown')
-    expect(wrapper.instance().props.rowIndex).toEqual(undefined)
-  })
-
   it('Pending status renders correct Icon', () => {
     const wrapper = shallow(<StatusCell status="pending" />)
     expect(wrapper.find('Icon').props().name).toEqual('clock')

--- a/src/lib/atoms/table-cells/text-cell.js
+++ b/src/lib/atoms/table-cells/text-cell.js
@@ -6,18 +6,16 @@ import getElementType from 'LibSrc/helpers/getElementType'
 import getUnhandledProps from 'LibSrc/helpers/getUnhandledProps'
 
 
-class TextCell extends React.PureComponent {
-  render() {
-    const ElementType = getElementType(TextCell, this.props)
-    const rest = getUnhandledProps(TextCell, this.props)
-    const { content } = this.props
+const TextCell = props => {
+  const ElementType = getElementType(TextCell, props)
+  const rest = getUnhandledProps(TextCell, props)
+  const { content } = props
 
-    return (
-      <ElementType {...rest}>
-        {content}
-      </ElementType>
-    )
-  }
+  return (
+    <ElementType {...rest}>
+      {content}
+    </ElementType>
+  )
 }
 
 
@@ -40,5 +38,6 @@ TextCell.handledProps = [
   'content',
   'rowIndex',
 ]
+
 
 export default TextCell

--- a/src/lib/atoms/table-cells/text-cell.test.js
+++ b/src/lib/atoms/table-cells/text-cell.test.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
-import { shallow } from 'enzyme'
 
 import { TextCell } from 'LibIndex'
 
@@ -9,19 +8,5 @@ describe('Test TextCell', () => {
   it('renders without crashing', () => {
     const div = document.createElement('div')
     ReactDOM.render(<TextCell rowIndex={1} content="hi" />, div)
-  })
-
-  it('initial props are set correctly', () => {
-    const wrapper = shallow(<TextCell rowIndex={1} content="hi" />)
-    expect(wrapper.instance().props.rowIndex).toEqual(1)
-    expect(wrapper.instance().props.as).toEqual('div')
-    expect(wrapper.instance().props.content).toEqual('hi')
-  })
-
-  it('initial props are set correctly as td', () => {
-    const wrapper = shallow(<TextCell as="td" rowIndex={1} content="hi" />)
-    expect(wrapper.instance().props.rowIndex).toEqual(1)
-    expect(wrapper.instance().props.as).toEqual('td')
-    expect(wrapper.instance().props.content).toEqual('hi')
   })
 })

--- a/src/lib/atoms/table-cells/transcript-cell.js
+++ b/src/lib/atoms/table-cells/transcript-cell.js
@@ -8,23 +8,21 @@ import getElementType from 'LibSrc/helpers/getElementType'
 import getUnhandledProps from 'LibSrc/helpers/getUnhandledProps'
 
 
-class TranscriptCell extends React.PureComponent {
-  render() {
-    const ElementType = getElementType(TranscriptCell, this.props)
-    const rest = getUnhandledProps(TranscriptCell, this.props)
-    const { transcript } = this.props
+const TranscriptCell = props => {
+  const ElementType = getElementType(TranscriptCell, props)
+  const rest = getUnhandledProps(TranscriptCell, props)
+  const { transcript } = props
 
 
-    return (
-      <ElementType {...rest}>
-        {transcript} &nbsp;&nbsp;
-        <Link
-          content={<Label basic size="tiny" content="A" color="brown" />}
-          href={utils.urlBuilders.alamutEntry(transcript)}
-        />
-      </ElementType>
-    )
-  }
+  return (
+    <ElementType {...rest}>
+      {transcript} &nbsp;&nbsp;
+      <Link
+        content={<Label basic size="tiny" content="A" color="brown" />}
+        href={utils.urlBuilders.alamutEntry(transcript)}
+      />
+    </ElementType>
+  )
 }
 
 
@@ -43,5 +41,6 @@ TranscriptCell.handledProps = [
   'transcript',
   'rowIndex',
 ]
+
 
 export default TranscriptCell

--- a/src/lib/atoms/table-cells/transcript-cell.test.js
+++ b/src/lib/atoms/table-cells/transcript-cell.test.js
@@ -11,13 +11,6 @@ describe('Test TranscriptCell', () => {
     ReactDOM.render(<TranscriptCell transcript="NM_011.1" />, div)
   })
 
-  it('initial props are set correctly', () => {
-    const wrapper = shallow(<TranscriptCell transcript="NM_011.1" />)
-    expect(wrapper.instance().props.as).toEqual('div')
-    expect(wrapper.instance().props.transcript).toEqual('NM_011.1')
-    expect(wrapper.instance().props.rowIndex).toEqual(undefined)
-  })
-
   it('children are rendered correctly (3 children and 1 Link)', () => {
     const wrapper = shallow(<TranscriptCell transcript="NM_011.1" />)
     expect(wrapper.props().children.length).toEqual(3)  // NOTE: space is counted as a child

--- a/src/lib/atoms/table-cells/turn-around-time-cell.js
+++ b/src/lib/atoms/table-cells/turn-around-time-cell.js
@@ -7,23 +7,21 @@ import getElementType from '../../helpers/getElementType'
 import getUnhandledProps from '../../helpers/getUnhandledProps'
 
 
-class TurnAroundTimeProgressCell extends React.PureComponent {
-  render() {
-    const ElementType = getElementType(TurnAroundTimeProgressCell, this.props)
-    const rest = getUnhandledProps(TurnAroundTimeProgressCell, this.props)
-    const { target, start, signout, progressProps } = this.props
+const TurnAroundTimeProgressCell = props => {
+  const ElementType = getElementType(TurnAroundTimeProgressCell, props)
+  const rest = getUnhandledProps(TurnAroundTimeProgressCell, props)
+  const { target, start, signout, progressProps } = props
 
-    return (
-      <ElementType {...rest}>
-        <TurnAroundTimeProgress
-          target={target}
-          start={start}
-          signout={signout}
-          {...progressProps}
-        />
-      </ElementType>
-    )
-  }
+  return (
+    <ElementType {...rest}>
+      <TurnAroundTimeProgress
+        target={target}
+        start={start}
+        signout={signout}
+        {...progressProps}
+      />
+    </ElementType>
+  )
 }
 
 
@@ -51,5 +49,6 @@ TurnAroundTimeProgressCell.handledProps = [
   'rowIndex',
   'progressProps',
 ]
+
 
 export default TurnAroundTimeProgressCell

--- a/src/lib/atoms/table-cells/turn-around-time-cell.test.js
+++ b/src/lib/atoms/table-cells/turn-around-time-cell.test.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
-import { shallow } from 'enzyme'
 
 import { TurnAroundTimeProgressCell } from 'LibIndex'
 
@@ -9,15 +8,5 @@ describe('Test TurnAroundTimeProgressCell', () => {
   it('renders without crashing', () => {
     const div = document.createElement('div')
     ReactDOM.render(<TurnAroundTimeProgressCell target={40} />, div)
-  })
-
-  it('initial props are set correctly', () => {
-    const wrapper = shallow(<TurnAroundTimeProgressCell target={40} />)
-    expect(wrapper.instance().props.as).toEqual('div')
-    expect(wrapper.instance().props.target).toEqual(40)
-    expect(wrapper.instance().props.start).toEqual(undefined)
-    expect(wrapper.instance().props.signout).toEqual(undefined)
-    expect(wrapper.instance().props.rowIndex).toEqual(undefined)
-    expect(wrapper.instance().props.progressProps).toEqual({ size: 'tiny' })
   })
 })

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -84,7 +84,7 @@ export { default as SaveForm } from 'LibSrc/molecules/forms/save-form'
 export { default as LoginForm } from 'LibSrc/molecules/forms/login-form'
 
 // Modals
-export { default as SaveFormModal } from 'LibSrc/molecules/modals/save-form-modal'
+export { default as FormModal } from 'LibSrc/molecules/modals/form-modal'
 
 // Menus
 export { default as DropdownMenu } from 'LibSrc/molecules/menus/dropdown-menu'

--- a/src/lib/molecules/forms/login-form.js
+++ b/src/lib/molecules/forms/login-form.js
@@ -124,4 +124,5 @@ LoginForm.defaultProps = {
   error: undefined,
 }
 
+
 export default LoginForm

--- a/src/lib/molecules/forms/save-form.js
+++ b/src/lib/molecules/forms/save-form.js
@@ -21,7 +21,8 @@ class SaveForm extends React.PureComponent {
     })
   }
 
-  onSubmit = () => {
+  onSubmit = e => {
+    e.preventDefault()
     const { handleSubmit } = this.props
 
     if (handleSubmit) {

--- a/src/lib/molecules/forms/save-form.test.js
+++ b/src/lib/molecules/forms/save-form.test.js
@@ -21,6 +21,8 @@ const form = (defaultValues, handleSubmit, handleChange) => {
 }
 
 describe('Test SaveForm', () => {
+  const event = {preventDefault: jest.fn()}
+
   it('renders without crashing', () => {
     const div = document.createElement('div')
     ReactDOM.render(form(), div)
@@ -46,7 +48,7 @@ describe('Test SaveForm', () => {
   it('onSubmit calls handleSubmit', () => {
     const handleSubmit = jest.fn()
     const wrapper = shallow(form({ 'test1': 'default' }, handleSubmit))
-    wrapper.find('Form').simulate('submit')
+    wrapper.find('Form').simulate('submit', event)
     expect(handleSubmit).toHaveBeenCalledWith({ 'test1': 'default' })
   })
 
@@ -61,7 +63,7 @@ describe('Test SaveForm', () => {
   it('handle handleSubmit when its undefined', () => {
     const wrapper = shallow(form())
     expect(wrapper.instance().state).toEqual({})
-    wrapper.find('Form').simulate('submit')
+    wrapper.find('Form').simulate('submit', event)
     expect(wrapper.instance().state).toEqual({})
   })
 })

--- a/src/lib/molecules/menus/dropdown-menu.js
+++ b/src/lib/molecules/menus/dropdown-menu.js
@@ -3,21 +3,19 @@ import PropTypes from 'prop-types'
 import { Dropdown, Icon } from 'semantic-ui-react'
 
 
-class DropdownMenu extends React.PureComponent {
-  render() {
-    const { children } = this.props
+const DropdownMenu = props => {
+  const { children } = props
 
-    return (
-      <Dropdown
-        trigger={<Icon name="sidebar" size="large" />}
-        icon={null}
-      >
-        <Dropdown.Menu className="NavbarDropdownMenu">
-          {children}
-        </Dropdown.Menu>
-      </Dropdown>
-    )
-  }
+  return (
+    <Dropdown
+      trigger={<Icon name="sidebar" size="large" />}
+      icon={null}
+    >
+      <Dropdown.Menu className="NavbarDropdownMenu">
+        {children}
+      </Dropdown.Menu>
+    </Dropdown>
+  )
 }
 
 
@@ -29,5 +27,6 @@ DropdownMenu.propTypes = {
 }
 
 DropdownMenu.defaultProps = {}
+
 
 export default DropdownMenu

--- a/src/lib/molecules/menus/navbar.js
+++ b/src/lib/molecules/menus/navbar.js
@@ -50,4 +50,5 @@ Navbar.defaultProps = {
   activeItem: '',
 }
 
+
 export default Navbar

--- a/src/lib/molecules/menus/user-menu.js
+++ b/src/lib/molecules/menus/user-menu.js
@@ -6,28 +6,25 @@ import * as customPropTypes from 'LibSrc/helpers/customPropTypes'
 import { Avatar } from 'LibIndex'
 
 
-class UserMenu extends React.PureComponent {
-  render () {
-    const { email, linksAs, name, profileImage } = this.props
+const UserMenu = props => {
+  const { email, linksAs, name, profileImage } = props
 
-    return (
-        <Dropdown
-          trigger={<Avatar profileImage={profileImage} />}
-          icon={null}
+  return (
+      <Dropdown
+        trigger={<Avatar profileImage={profileImage} />}
+        icon={null}
+      >
+        <Dropdown.Menu
+          className="NavbarDropdownMenu"
         >
-          <Dropdown.Menu
-            className="NavbarDropdownMenu"
-          >
-            <Dropdown.Item text={name} />
-            <Dropdown.Item text={email} disabled />
-            <Divider />
-            <Dropdown.Item text="Settings" as={linksAs} to="settings" href="settings" />
-            <Dropdown.Item text="Sign Out" as={linksAs} to="logoff" href="logoff" />
-          </Dropdown.Menu>
-        </Dropdown>
-    )
-  }
-
+          <Dropdown.Item text={name} />
+          <Dropdown.Item text={email} disabled />
+          <Divider />
+          <Dropdown.Item text="Settings" as={linksAs} to="settings" href="settings" />
+          <Dropdown.Item text="Sign Out" as={linksAs} to="logoff" href="logoff" />
+        </Dropdown.Menu>
+      </Dropdown>
+  )
 }
 
 
@@ -42,5 +39,6 @@ UserMenu.propTypes = {
 UserMenu.defaultProps = {
   linksAs: 'a',
 }
+
 
 export default UserMenu

--- a/src/lib/molecules/modals/form-modal.js
+++ b/src/lib/molecules/modals/form-modal.js
@@ -6,7 +6,7 @@ import { get } from 'lodash'
 import { Button, CancelButton, SaveForm } from 'LibIndex'
 
 
-class SaveFormModal extends React.PureComponent {
+class FormModal extends React.PureComponent {
   constructor(props) {
     super(props)
 
@@ -15,7 +15,7 @@ class SaveFormModal extends React.PureComponent {
     }
   }
 
-  onSubmit = (values) => {
+  onSubmit = values => {
     const { handleSubmit } = this.props
     if (handleSubmit) {
       handleSubmit(values)
@@ -33,43 +33,52 @@ class SaveFormModal extends React.PureComponent {
   }
 
   render() {
-    const { defaultValues, handleChange } = this.props
+    const {
+      cancelButton,
+      children,
+      defaultValues,
+      formId,
+      handleChange,
+      saveButton,
+      title
+    } = this.props
+
+    const { visible } = this.state
 
     const trigger = React.cloneElement(this.props.trigger, {
       onClick: this.open,
     })
 
+    const save = React.cloneElement(saveButton, {
+      type: 'submit',
+      form: formId,
+    })
+
+    const cancel = React.cloneElement(cancelButton, {
+      onClick: this.close,
+    })
+
     return (
       <Modal
         trigger={trigger}
-        open={this.state.visible}
+        open={visible}
       >
-        <Modal.Header>{this.props.title}</Modal.Header>
+        <Modal.Header>{title}</Modal.Header>
 
         <Modal.Content>
           <SaveForm
-            id={this.props.formId}
+            id={formId}
             defaultValues={defaultValues}
             handleChange={handleChange}
             handleSubmit={this.onSubmit}
           >
-            {this.props.children}
+            {children}
           </SaveForm>
         </Modal.Content>
 
         <Modal.Actions>
-          <Button
-            type="submit"
-            form={this.props.formId}
-            content="Save"
-            icon="save"
-            color="action-positive"
-            inverted
-          />
-          <CancelButton
-            onClick={this.close}
-            inverted
-          />
+          {save}
+          {cancel}
         </Modal.Actions>
       </Modal>
     )
@@ -77,7 +86,7 @@ class SaveFormModal extends React.PureComponent {
 }
 
 
-SaveFormModal.propTypes = {
+FormModal.propTypes = {
   formId: PropTypes.string.isRequired,
   trigger: PropTypes.element.isRequired,
   title: PropTypes.string.isRequired,
@@ -85,11 +94,24 @@ SaveFormModal.propTypes = {
   handleChange: PropTypes.func,
   open: PropTypes.bool,
   defaultValues: PropTypes.shape({}),
+  saveButton: PropTypes.any,
+  cancelButton: PropTypes.any,
 }
 
-SaveFormModal.defaultProps = {
+FormModal.defaultProps = {
   open: false,
   defaultValues: {},
+  saveButton: (
+    <Button
+      type="submit"
+      content="Save"
+      icon="save"
+      color="action-positive"
+      inverted
+    />
+  ),
+  cancelButton: <CancelButton inverted />
 }
 
-export default SaveFormModal
+
+export default FormModal

--- a/src/lib/molecules/modals/form-modal.test.js
+++ b/src/lib/molecules/modals/form-modal.test.js
@@ -3,12 +3,12 @@ import ReactDOM from 'react-dom'
 import { Form } from 'semantic-ui-react'
 import { mount, shallow } from 'enzyme'
 
-import { SaveFormModal } from 'LibIndex'
+import { FormModal } from 'LibIndex'
 
 
 const form = (open = false, title = 'title', handleSubmit = jest.fn(), handleChange = jest.fn()) => {
   return (
-    <SaveFormModal
+    <FormModal
       className="test-modal"
       formId="test"
       title={title}
@@ -19,17 +19,17 @@ const form = (open = false, title = 'title', handleSubmit = jest.fn(), handleCha
       defaultValues={{ test1: 'default' }}
     >
       <Form.Input id="test1" name="test1" />
-    </SaveFormModal>
+    </FormModal>
   )
 }
 
-describe('Test SaveFormModal', () => {
-  it('SaveFormModal renders without crashing', () => {
+describe('Test FormModal', () => {
+  it('FormModal renders without crashing', () => {
     const div = document.createElement('div')
     ReactDOM.render(form(), div)
   })
 
-  it('SaveFormModal initial props are set correctly', () => {
+  it('FormModal initial props are set correctly', () => {
     const wrapper = mount(form(false, 'test', jest.fn()))
     expect(wrapper.find('.test-modal').props().formId).toBe('test')
     expect(wrapper.find('.test-modal').props().trigger).toEqual(<p className="trigger">trigger</p>)
@@ -38,14 +38,14 @@ describe('Test SaveFormModal', () => {
     expect(wrapper.find('.test-modal').props().defaultValues).toEqual({ 'test1': 'default' })
   })
 
-  it('SaveFormModal handle onClick of trigger', () => {
+  it('FormModal handle onClick of trigger', () => {
     const wrapper = mount(form())
     expect(wrapper.state().visible).toEqual(false)
     wrapper.find('.trigger').simulate('click')
     expect(wrapper.state().visible).toEqual(true)
   })
 
-  it('SaveFormModal onClick of trigger calls open()', () => {
+  it('FormModal onClick of trigger calls open()', () => {
     const wrapper = mount(form())
     const instance = wrapper.instance()
     const spy = jest.spyOn(instance, 'open')
@@ -81,7 +81,7 @@ describe('Test SaveFormModal', () => {
 
   // it('onSubmit does not call handleSubmit if not set', () => {
   //   const element = (
-  //     <SaveFormModal
+  //     <FormModal
   //       className="test-modal"
   //       formId="test"
   //       title="title"
@@ -89,7 +89,7 @@ describe('Test SaveFormModal', () => {
   //       open
   //       >
   //         <Form.Input id="test1" name="test1" />
-  //     </SaveFormModal>
+  //     </FormModal>
   //   )
   //   const wrapper = shallow(element)
   //   const instance = wrapper.instance()

--- a/src/lib/molecules/tables/big-data-table.js
+++ b/src/lib/molecules/tables/big-data-table.js
@@ -6,7 +6,7 @@ import { concat, differenceWith, isEqual } from 'lodash'
 import cx from 'classnames'
 
 
-class BigDataTable extends React.PureComponent {
+class BigDataTable extends React.Component {
   constructor(props, context) {
     super(props)
 
@@ -106,5 +106,6 @@ BigDataTable.defaultProps = {
   rowTextAlign: 'left',
   scrollToIndex: -1,
 }
+
 
 export default BigDataTable

--- a/src/lib/molecules/tables/fixed-data-table.js
+++ b/src/lib/molecules/tables/fixed-data-table.js
@@ -5,7 +5,7 @@ import { Table } from 'fixed-data-table-2'
 import { get, indexOf, map, sortBy } from 'lodash'
 
 
-class FixedDataTable extends React.PureComponent {
+class FixedDataTable extends React.Component {
   constructor(props) {
     super(props)
 
@@ -119,5 +119,6 @@ FixedDataTable.propTypes = {
 FixedDataTable.defaultProps = {
   fixedColumns: [],
 }
+
 
 export default FixedDataTable


### PR DESCRIPTION
Dear Maintainers,

Converted small components that don't require state to stateless components to improve efficiency