### PR TITLE
Resolved #184 - Handle checked state of checkbox outside of component

### DIFF
--- a/src/demo/components/BigDataTableExample.js
+++ b/src/demo/components/BigDataTableExample.js
@@ -62,7 +62,7 @@ const ExampleInfiniteTable = () => (
           label="Checkbox"
           dataKey="checkbox"
           width={100}
-          columnData={{ onChange: (props) => alert(JSON.stringify(props)) }}
+          columnData={{ onChange: () => alert('clicked'), checked: [] }}
         />
         <DropdownColumn
           label="Dropdown"

--- a/src/demo/components/FixedDataTableExample.js
+++ b/src/demo/components/FixedDataTableExample.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { Cell, Column } from 'fixed-data-table-2'
 import { Grid } from 'semantic-ui-react'
+import { concat, without } from 'lodash'
 
 import {
   FixedDataTable,
@@ -21,7 +22,7 @@ import {
 
 const rows = Array.from(new Array(30), (x,i) => ({
   id: i,
-  checkbox: true,
+  checkbox: i,
   interpretation: 'benign',
   link: 'link',
   consequence: 'missense',
@@ -82,7 +83,25 @@ const columnOrder = [
 
 
 class FixedDataTableExample extends React.PureComponent {
+  state = { checked: [] }
+
+  onCheck = (e, {value}) => {
+    const { checked } = this.state
+
+    if (checked.includes(value)) {
+      this.setState({
+        checked: without(checked, value)
+      })
+    } else {
+      this.setState({
+        checked: concat(checked, value)
+      })
+    }
+  }
+
   render() {
+    const { checked } = this.state
+
     return (
       <Grid padded centered>
         <Grid.Column width={16} textAlign="center">
@@ -102,7 +121,8 @@ class FixedDataTableExample extends React.PureComponent {
               cell={
                 <CheckboxFixedCell
                   data={rows}
-                  onChange={(props) => alert(JSON.stringify(props))}
+                  onChange={this.onCheck}
+                  checked={checked}
                 />
               }
               width={200}

--- a/src/demo/components/TableCellExamples.js
+++ b/src/demo/components/TableCellExamples.js
@@ -1,5 +1,7 @@
 import React from 'react'
 import { Grid, Table } from 'semantic-ui-react'
+import { concat, without } from 'lodash'
+
 
 import {
   CheckboxCell,
@@ -23,7 +25,8 @@ class ExampleTableCells extends React.Component {
     super(props)
 
     this.state = {
-      value: ''
+      value: '',
+      checked: [],
     }
   }
 
@@ -35,8 +38,22 @@ class ExampleTableCells extends React.Component {
     alert(JSON.stringify(data))
   }
 
+  onCheck = (e, {value}) => {
+    const { checked } = this.state
+
+    if (checked.includes(value)) {
+      this.setState({
+        checked: without(checked, value)
+      })
+    } else {
+      this.setState({
+        checked: concat(checked, value)
+      })
+    }
+  }
+
   render() {
-    const { value } = this.state
+    const { value, checked } = this.state
 
     return (
       <Grid padded centered>
@@ -66,7 +83,9 @@ class ExampleTableCells extends React.Component {
                 <CheckboxCell
                   as="td"
                   rowIndex={1}
-                  onChange={this.onChange}
+                  onChange={this.onCheck}
+                  name="checkbox"
+                  checked={checked}
                 />
                 <DateCell
                   as="td"

--- a/src/lib/atoms/fixed-data-table-cells/checkbox-fixed-cell.js
+++ b/src/lib/atoms/fixed-data-table-cells/checkbox-fixed-cell.js
@@ -5,44 +5,34 @@ import { Checkbox } from 'semantic-ui-react'
 import { get } from 'lodash'
 
 
-class CheckboxFixedCell extends React.Component {
-  constructor(props) {
-    super(props)
+const CheckboxFixedCell = props => {
+  const { data, rowIndex, columnKey, onChange, checked, ...rest } = props
+  const record = get(data[rowIndex], columnKey)
 
-    const { data, rowIndex, columnKey } = props
-    const checked = get(data[rowIndex], columnKey)
-    this.state = { checked }
-  }
-
-  onChange = (e) => {
-    const { onChange, data, rowIndex, columnKey } = this.props
-    const checked = get(data[rowIndex], columnKey)
-    onChange(rowIndex)
-    this.setState({ checked })
-  }
-
-  render() {
-    const { onChange, data, rowIndex, columnKey, ...rest } = this.props
-    const { checked } = this.state
-
-    return (
-      <Cell {...rest}>
-        <Checkbox defaultChecked={checked} onChange={this.onChange} />
-      </Cell>
-    )
-  }
+  return (
+    <Cell {...rest}>
+      <Checkbox
+        name={columnKey}
+        value={record}
+        checked={checked.includes(record)}
+        onChange={onChange}
+      />
+    </Cell>
+  )
 }
 
 
 CheckboxFixedCell.propTypes = {
-  onChange: PropTypes.func.isRequired,
   data: PropTypes.arrayOf(PropTypes.object),
   rowIndex: PropTypes.number,
   columnKey: PropTypes.string,
+  onChange: PropTypes.func.isRequired,
+  checked: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number]))
 }
 
 CheckboxFixedCell.defaultProps = {
   data: [],
+  checked: [],
 }
 
 

--- a/src/lib/atoms/fixed-data-table-cells/checkbox-fixed-cell.test.js
+++ b/src/lib/atoms/fixed-data-table-cells/checkbox-fixed-cell.test.js
@@ -7,9 +7,11 @@ import { CheckboxFixedCell } from 'LibIndex'
 
 describe('Test CheckboxFixedCell', () => {
   const data = [
-    { checkbox: false },
-    { checkbox: true },
+    { checkbox: 1 },
+    { checkbox: 2 },
   ]
+
+  const checked = [1]
 
   it('renders without crashing', () => {
     const div = document.createElement('div')
@@ -19,6 +21,7 @@ describe('Test CheckboxFixedCell', () => {
         rowIndex={1}
         columnKey="checkbox"
         onChange={jest.fn()}
+        checked={checked}
       />
     )
     ReactDOM.render(element, div)
@@ -31,10 +34,11 @@ describe('Test CheckboxFixedCell', () => {
         rowIndex={0}
         columnKey="checkbox"
         onChange={jest.fn()}
+        checked={checked}
       />
     )
     const wrapper = shallow(element)
-    expect(wrapper.find('Checkbox').props().defaultChecked).toEqual(false)
+    expect(wrapper.find('Checkbox').props().checked).toEqual(true)
   })
 
   it('renders the second record date with rowIndex = 1', () => {
@@ -44,10 +48,11 @@ describe('Test CheckboxFixedCell', () => {
         rowIndex={1}
         columnKey="checkbox"
         onChange={jest.fn()}
+        checked={checked}
       />
     )
     const wrapper = shallow(element)
-    expect(wrapper.find('Checkbox').props().defaultChecked).toEqual(true)
+    expect(wrapper.find('Checkbox').props().checked).toEqual(false)
   })
 
   it('when checkbox changes, value is retrieved from data', () => {
@@ -58,12 +63,11 @@ describe('Test CheckboxFixedCell', () => {
         rowIndex={0}
         columnKey="checkbox"
         onChange={onChange}
+        checked={checked}
       />
     )
     const wrapper = shallow(element)
-    expect(wrapper.instance().state.checked).toEqual(false)
-    wrapper.find('Checkbox').simulate('change')
-    expect(onChange).toHaveBeenCalledWith(0)
-    expect(wrapper.instance().state.checked).toEqual(false)
+    const observerd = wrapper.find('Checkbox').props().onChange
+    expect(observerd).toEqual(onChange)
   })
 })

--- a/src/lib/atoms/table-cells/checkbox-cell.js
+++ b/src/lib/atoms/table-cells/checkbox-cell.js
@@ -7,39 +7,39 @@ import getElementType from 'LibSrc/helpers/getElementType'
 import getUnhandledProps from 'LibSrc/helpers/getUnhandledProps'
 
 
-class CheckboxCell extends React.Component {
-  onChange = (e) => {
-    const { onChange, rowIndex } = this.props
-    onChange(rowIndex)
-  }
+const CheckboxCell = props => {
+  const ElementType = getElementType(CheckboxCell, props)
+  const rest = getUnhandledProps(CheckboxCell, props)
 
-  render() {
-    const ElementType = getElementType(CheckboxCell, this.props)
-    const rest = getUnhandledProps(CheckboxCell, this.props)
-
-    return (
-      <ElementType {...rest}>
-        <Checkbox onChange={this.onChange} />
-      </ElementType>
-    )
-  }
+  return (
+    <ElementType key={props.rowIndex} {...rest}>
+      <Checkbox
+        name={props.name}
+        value={props.rowIndex}
+        checked={props.checked.includes(props.rowIndex)}
+        onChange={props.onChange}
+      />
+    </ElementType>
+  )
 }
 
 
 CheckboxCell.propTypes = {
   as: customPropTypes.as,
   onChange: PropTypes.func.isRequired,
-  rowIndex: PropTypes.number.isRequired,
+  checked: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number]))
 }
 
 CheckboxCell.defaultProps = {
-  as: 'div'
+  as: 'div',
+  checked: [],
 }
 
 CheckboxCell.handledProps = [
   'as',
   'onChange',
   'rowIndex',
+  'checked',
 ]
 
 

--- a/src/lib/atoms/table-cells/checkbox-cell.test.js
+++ b/src/lib/atoms/table-cells/checkbox-cell.test.js
@@ -11,22 +11,13 @@ describe('Test CheckboxCell', () => {
     ReactDOM.render(<CheckboxCell rowIndex={1} onChange={jest.fn()} />, div)
   })
 
-  it('initial props are set correctly', () => {
+  it('checked is false when rowIndex not in checked', () => {
     const wrapper = shallow(<CheckboxCell rowIndex={1} onChange={jest.fn()} />)
-    expect(wrapper.instance().props.rowIndex).toEqual(1)
-    expect(wrapper.instance().props.as).toEqual('div')
+    expect(wrapper.find('Checkbox').props().checked).toEqual(false)
   })
 
-  it('non default props are set correctly as td', () => {
-    const wrapper = shallow(<CheckboxCell as="td" rowIndex={1} onChange={jest.fn()} />)
-    expect(wrapper.instance().props.rowIndex).toEqual(1)
-    expect(wrapper.instance().props.as).toEqual('td')
-  })
-
-  it('onChange is called correctly', () => {
-    const onChange = jest.fn()
-    const wrapper = shallow(<CheckboxCell rowIndex={1} onChange={onChange} />)
-    wrapper.find('Checkbox').simulate('change')
-    expect(onChange).toHaveBeenCalledWith(1)
+  it('checked is true when rowIndex in checked', () => {
+    const wrapper = shallow(<CheckboxCell rowIndex={1} checked={[1]} onChange={jest.fn()} />)
+    expect(wrapper.find('Checkbox').props().checked).toEqual(true)
   })
 })

--- a/src/lib/molecules/table-columns/checkbox-column.js
+++ b/src/lib/molecules/table-columns/checkbox-column.js
@@ -22,12 +22,13 @@ const cellRenderer = (props) => {
   // See: https://github.com/bvaughn/react-virtualized/blob/master/docs/Column.md#cellrenderer
   // props: { cellData, columnData, columnIndex, dataKey, isScrolling, rowData, rowIndex }
   const { columnData, rowIndex } = props
-  const { onChange } = columnData
+  const { onChange, checked } = columnData
 
   return (
     <CheckboxCell
       onChange={onChange}
       rowIndex={rowIndex}
+      checked={checked}
     />
   )
 }
@@ -48,6 +49,7 @@ class CheckboxColumn extends Column {
     headerRenderer: PropTypes.func.isRequired,
     columnData: PropTypes.shape({
       onChange: PropTypes.func.isRequired,
+      checked: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number])).isRequired,
     }).isRequired,
   }
 

--- a/src/lib/molecules/table-columns/checkbox-column.test.js
+++ b/src/lib/molecules/table-columns/checkbox-column.test.js
@@ -13,7 +13,10 @@ describe('Test CheckboxColumn', () => {
         label="test"
         dataKey={dataKey}
         width={100}
-        columnData={{onChange: jest.fn()}}
+        columnData={{
+          onChange: jest.fn(),
+          checked: [],
+        }}
       />
     )
     const wrapper = shallow(element)
@@ -26,7 +29,7 @@ describe('Test CheckboxColumn', () => {
     const dataKey = 'name'
     const rowIndex = 1
     const onChange = jest.fn()
-    const columnData= { onChange: onChange }
+    const columnData= { onChange: onChange, checked: [1] }
     const element = (
       <CheckboxColumn
         label="test"
@@ -37,7 +40,7 @@ describe('Test CheckboxColumn', () => {
     )
     const wrapper = shallow(element)
     expect(wrapper.find('Column').props().cellRenderer({ dataKey, columnData, cellData, rowIndex }))
-      .toEqual(<CheckboxCell as="div" onChange={onChange} rowIndex={1} />)
+      .toEqual(<CheckboxCell as="div" onChange={onChange} rowIndex={1} checked={[1]} />)
   })
 
   it('headerRenderer returns expected content', () => {
@@ -47,7 +50,7 @@ describe('Test CheckboxColumn', () => {
         label={label}
         dataKey="test"
         width={100}
-        columnData={{onChange: jest.fn()}}
+        columnData={{onChange: jest.fn(), checked: []}}
       />
     )
     const wrapper = shallow(element)


### PR DESCRIPTION
Dear Maintainers,

Please accept this PR that addresses the following issues:
+ *Resolved #184 - allows parent component to deal with checked status by passing a prop called `checked` that contains all values that are checked*
+ *Resolved #140 - defaultChecked is not used - just uses value to figure out if it should be checked or not*

Testing Done:
+ Unittests are updated

