### PR TITLE
Resolved #272 - Allow Export Button to also handle custom onClick methods

### DIFF
--- a/src/lib/atoms/buttons/ExportButton.js
+++ b/src/lib/atoms/buttons/ExportButton.js
@@ -7,14 +7,18 @@ import { get } from 'lodash'
 import { Button } from 'LibIndex'
 
 
-class ExportButton extends React.PureComponent {
-  handleReformat = () => {
-    const { data, onExport } = this.props
+class ExportButton extends React.Component {
+  handleReformat = (e, props) => {
+    const { data, onExport, onClick } = this.props
 
     if (onExport) {
       this.setState({ data: onExport(data) })
     } else {
       this.setState({ data })
+    }
+
+    if (onClick) {
+      onClick(e, props)
     }
   }
 
@@ -48,6 +52,7 @@ ExportButton.propTypes = {
   ]),
   filenamePrefix: PropTypes.string,
   onExport: PropTypes.func,
+  onClick: PropTypes.func,
 }
 
 ExportButton.defaultProps = {

--- a/src/lib/atoms/buttons/ExportButton.test.js
+++ b/src/lib/atoms/buttons/ExportButton.test.js
@@ -62,4 +62,18 @@ describe('Test ExportButton', () => {
     wrapper.find('CSVLink').props().children.props.onClick()
     expect(wrapper.state().data).toEqual([{ test: 1, test2: 2 }])
   })
+
+  it('onClick is passed and called', () => {
+    const onClick = jest.fn()
+    const wrapper = shallow(
+      <ExportButton
+        data={[{ test: 1, test2: 2 }]}
+        filenamePrefix="newPrefix"
+        onClick={onClick}
+      />
+    )
+
+    wrapper.find('Button').simulate('click', {'hi': 1}, 'Mike')
+    expect(onClick).toHaveBeenCalledWith({"hi": 1}, 'Mike')
+  })
 })


### PR DESCRIPTION
Dear Maintainers,

Please accept this PR that addresses the following issues:
+ *#272 - Allow export button to handle custom onClick methods*

Testing Done:
+ Unittests were updated

