### PR TITLE
Removed unsafe/deprecated React life cycle methods

### DIFF
--- a/src/lib/atoms/dropdowns/autocomplete-dropdown.js
+++ b/src/lib/atoms/dropdowns/autocomplete-dropdown.js
@@ -5,6 +5,16 @@ import { omit } from 'lodash'
 
 
 class AutoCompleteDropDown extends React.Component {
+  static getDerivedStateFromProps(props, state) {
+    const { loading } = props
+
+    if (loading !== state.loading) {
+      return { loading }
+    }
+
+    return null
+  }
+
   constructor(props) {
     super(props)
 
@@ -13,16 +23,8 @@ class AutoCompleteDropDown extends React.Component {
     }
   }
 
-  componentWillMount() {
+  componentDidMount() {
     this.timeout = null
-  }
-
-  componentWillReceiveProps(nextProps) {
-    const { loading } = this.props
-
-    if (nextProps.loading !== loading) {
-      this.setState({ loading: nextProps.loading })
-    }
   }
 
   onSearchChange = (e, { searchQuery }) => {

--- a/src/lib/molecules/forms/login-form.js
+++ b/src/lib/molecules/forms/login-form.js
@@ -6,6 +6,16 @@ import { Button } from 'LibIndex'
 
 
 class LoginForm extends React.Component {
+  static getDerivedStateFromProps(props, state) {
+    const { loading, error } = props
+
+    if (loading !== state.loading || error !== state.error) {
+      return { loading, error }
+    }
+
+    return null
+  }
+
   constructor(props) {
     super(props)
 
@@ -14,18 +24,6 @@ class LoginForm extends React.Component {
       password: '',
       loading: props.loading,
       error: props.error,
-    }
-  }
-
-  componentWillReceiveProps(nextProps) {
-    const { loading, error } = this.props
-
-    if (nextProps.loading !== loading) {
-      this.setState({ loading: nextProps.loading })
-    }
-
-    if (nextProps.error !== error) {
-      this.setState({ error: nextProps.error })
     }
   }
 

--- a/src/lib/molecules/tables/big-data-table.js
+++ b/src/lib/molecules/tables/big-data-table.js
@@ -7,28 +7,25 @@ import cx from 'classnames'
 
 
 class BigDataTable extends React.Component {
+  static getDerivedStateFromProps(props, state) {
+    const { data, loading } = props
+    const { rows } = state
+
+    const difference = differenceWith(data, rows, isEqual)
+
+    if (loading !== state.loading || difference.length > 0) {
+      return { loading, rows: concat(rows, difference) }
+    }
+
+    return null
+  }
+
   constructor(props, context) {
     super(props)
 
     this.state = {
       rows: props.data,
       loading: props.loading,
-    }
-  }
-
-  componentWillReceiveProps(nextProps) {
-    const { data, loading } = this.props
-
-    if (nextProps.data !== data) {
-      const { rows } = this.state
-      const newData = differenceWith(nextProps.data, rows, isEqual)
-      if (newData.length > 0) {
-        this.setState({ rows: concat(rows, newData) })
-      }
-    }
-
-    if (nextProps.loading !== loading) {
-      this.setState({ loading: nextProps.loading })
     }
   }
 

--- a/src/lib/molecules/tables/fixed-data-table.js
+++ b/src/lib/molecules/tables/fixed-data-table.js
@@ -6,24 +6,22 @@ import { get, indexOf, map, sortBy } from 'lodash'
 
 
 class FixedDataTable extends React.Component {
+  static getDerivedStateFromProps(props, state) {
+    const { columnWidths, columnOrder } = props
+
+    if (columnWidths !== state.columnWidths || columnOrder !== state.columnOrder) {
+      return { columnWidths, columnOrder }
+    }
+
+    return null
+  }
+
   constructor(props) {
     super(props)
 
     this.state = {
       columnWidths: props.columnWidths,
       columnOrder: props.columnOrder,
-    }
-  }
-
-  componentWillReceiveProps(nextProps) {
-    const { columnWidths, columnOrder } = this.props
-
-    if (nextProps.columnWidths !== columnWidths) {
-      this.setState({ columnWidths: nextProps.columnWidths })
-    }
-
-    if (nextProps.columnOrder !== columnOrder) {
-      this.setState({ columnOrder: nextProps.columnOrder })
     }
   }
 


### PR DESCRIPTION
Dear Maintainers,

Please accept this PR that addresses the following issues:
+ *React 0.16.4 deprecated some unsafe life cycle component methods.  These have been changed in this package*

Testing Done:
+ Unittests should be unaffected
