### PR TITLE
Allow user to control maxHeight of FixedDataTable.  Autosizer creates weird behavior with div

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: node_js
 
 node_js:
- - "11"
+  # See: https://github.com/facebook/jest/issues/8069#issuecomment-470307590
+  - '11.10.1'
 
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash
@@ -12,5 +13,5 @@ install:
   - yarn install
 
 script:
- - yarn run test --maxWorkers=4
- - codecov
+  - yarn run test --maxWorkers=4
+  - codecov

--- a/demo/src/components/FixedDataTableExample.js
+++ b/demo/src/components/FixedDataTableExample.js
@@ -82,12 +82,14 @@ const columnOrder = [
 
 const FixedDataTableExample = () => {
   const [checked, setChecked] = hooks.useStateList([])
+  const { innerHeight: height } = hooks.useWindowSize()
 
   return (
-    <Segment basic size="mini" style={{ padding: 0, width: '100%', height: '500px' }} textAlign="center">
+    <Segment basic size="mini" style={{ padding: 0, width: '100%' }} textAlign="center">
       <FixedDataTable
         headerHeight={55}
         rowHeight={40}
+        maxHeight={height - 400}
         columnWidths={columnWidths}
         columnOrder={columnOrder}
         isColumnResizing={false}

--- a/src/tables/fixed-data-table.js
+++ b/src/tables/fixed-data-table.js
@@ -12,6 +12,7 @@ const FixedDataTable = props => {
     onColumnResize,
     children,
     fixedColumns,
+    maxHeight,
     ...rest
   } = props
 
@@ -60,15 +61,15 @@ const FixedDataTable = props => {
   // NOTE: AutoSizer needs to have a parent component specify the height and width
   // NOTE: See https://github.com/bvaughn/react-virtualized/blob/master/docs/usingAutoSizer.md
   return (
-    <AutoSizer>
-      {({ height, width }) => (
+    <AutoSizer disableHeight>
+      {({ width }) => (
         <Table
           {...rest}
           className="genomix fixed-data table"
           width={width}
           onColumnResizeEndCallback={onColumnResizeEndCallback}
           onColumnReorderEndCallback={onColumnReorderEndCallback}
-          maxHeight={height}
+          maxHeight={maxHeight}
         >
           {orderedChildren}
         </Table>
@@ -78,14 +79,17 @@ const FixedDataTable = props => {
 }
 
 FixedDataTable.propTypes = {
+  columnWidths: PropTypes.object.isRequired,
   columnOrder: PropTypes.arrayOf(PropTypes.string).isRequired,
   onColumnReorder: PropTypes.func,
-  columnWidths: PropTypes.object.isRequired,
-  onResizeColumn: PropTypes.func,
+  onColumnResize: PropTypes.func,
+  children: PropTypes.any,
+  maxHeight: PropTypes.number,
   fixedColumns: PropTypes.arrayOf(PropTypes.string),
 }
 
 FixedDataTable.defaultProps = {
+  maxHeight: 400,
   fixedColumns: [],
 }
 


### PR DESCRIPTION
Instead of trying to automatically size parent div, its better to allow user to provide maxHeight.  Using `useWindowSize` hook, now we can make it responsive easily.  Check demo :)