### PR TITLE
Added a table using fixed-data-table that allows for infinite scrolling.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -99,3 +99,4 @@ export { default as UserMenu } from './menus/user-menu'
 
 // Tables
 export { default as FixedDataTable } from './tables/fixed-data-table'
+export { default as InfiniteScrollTable } from './tables/infinite-scroll-table'

--- a/src/tables/infinite-scroll-table.js
+++ b/src/tables/infinite-scroll-table.js
@@ -1,0 +1,50 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Segment } from 'semantic-ui-react'
+
+import { hooks, FixedDataTable } from '../index'
+
+const InfiniteScrollTable = ({
+  hasNextPage = false,
+  loading = false,
+  rows = [],
+  children,
+  yOffset,
+  onFetch,
+  onScrollEnd,
+  segment = { size: 'mini', style: { padding: 0, width: '100%' }, textAlign: 'center' },
+  ...rest
+}) => {
+  const { innerHeight: height } = hooks.useWindowSize()
+  const maxHeight = height - yOffset
+  return (
+    <Segment loading={loading} {...segment}>
+      <FixedDataTable
+        maxHeight={maxHeight}
+        rowsCount={rows.length}
+        onScrollEnd={(x, y, row) => {
+          const heightLeft = (rows.length - row) * 40
+          const difference = heightLeft - maxHeight
+          if (difference < 100 && hasNextPage && onFetch) onFetch()
+          if (onScrollEnd) onScrollEnd()
+        }}
+        {...rest}
+      >
+        {children}
+      </FixedDataTable>
+    </Segment>
+  )
+}
+
+InfiniteScrollTable.propTypes = {
+  hasNextPage: PropTypes.bool,
+  loading: PropTypes.bool,
+  rows: PropTypes.array,
+  children: PropTypes.node,
+  yOffset: PropTypes.number,
+  onFetch: PropTypes.func,
+  onScrollEnd: PropTypes.func,
+  segment: PropTypes.shape(),
+}
+
+export default InfiniteScrollTable

--- a/src/tables/infinite-scroll-table.test.js
+++ b/src/tables/infinite-scroll-table.test.js
@@ -1,0 +1,38 @@
+import React from 'react'
+import ReactDOM from 'react-dom'
+import { Cell, Column } from 'fixed-data-table-2'
+
+import { InfiniteScrollTable, TextFixedCell } from '../index'
+
+const list = Array.from(new Array(1), (x, i) => ({
+  name: 'Mike',
+  text: 'text',
+}))
+
+const initialColumnOrder = ['name', 'text']
+const initialColumnSizes = { name: 50, text: 100 }
+
+const TestTable = ({ ...props }) => {
+  return (
+    <InfiniteScrollTable
+      maxHeight={500}
+      headerHeight={100}
+      rowHeight={100}
+      columnOrder={initialColumnOrder}
+      onColumnReorder={props.onColumnReorder}
+      columnWidths={initialColumnSizes}
+      onColumnResize={props.onColumnResize}
+      fixedColumns={props.fixedColumns}
+    >
+      <Column header={<Cell>Header</Cell>} cell={<TextFixedCell data={props.data} />} columnKey="name" width={100} />
+      <Column header={<Cell>Header</Cell>} cell={<TextFixedCell data={props.data} />} columnKey="text" width={100} />
+    </InfiniteScrollTable>
+  )
+}
+
+describe('Test FixedDataTable', () => {
+  it('renders without crashing', () => {
+    const div = document.createElement('div')
+    ReactDOM.render(<TestTable rows={list} />, div)
+  })
+})


### PR DESCRIPTION
Dear Maintainers,

Please accept this PR that addresses the following issues:
+ *Added a virtualized that allows for infinite scrolling.  Using the two props `hasNextPage` and `onFetch` to control the requesting of additional data for the table*

